### PR TITLE
Partial qt6 port

### DIFF
--- a/NifSkope.pro
+++ b/NifSkope.pro
@@ -5,7 +5,7 @@
 TEMPLATE = app
 TARGET   = NifSkope
 
-QT += xml opengl network widgets
+QT += xml openglwidgets network widgets
 
 # Require Qt 5.7 or higher
 contains(QT_VERSION, ^5\\.[0-6]\\..*) {

--- a/src/data/nifvalue.cpp
+++ b/src/data/nifvalue.cpp
@@ -300,7 +300,7 @@ quint32 NifValue::enumOptionValue( const QString & eid, const QString & oid, boo
 				*ok = true;
 
 			quint32 value = 0;
-			QStringList list = oid.split( QRegularExpression( "\\s*\\|\\s*" ), QString::SkipEmptyParts );
+			QStringList list = oid.split( QRegularExpression( "\\s*\\|\\s*" ), Qt::SkipEmptyParts );
 			QStringListIterator lit( list );
 
 			while ( lit.hasNext() ) {

--- a/src/gl/bsshape.cpp
+++ b/src/gl/bsshape.cpp
@@ -204,12 +204,12 @@ QModelIndex BSShape::vertexAt( int idx ) const
 	auto blk = iBlock;
 	if ( nifVersion < 130 && iSkinPart.isValid() ) {
 		if ( nif->inherits( blk, "BSDynamicTriShape" ) )
-			return nif->getIndex( blk, "Vertices" ).child( idx, 0 );
+			return nif->index(idx, 0, nif->getIndex( blk, "Vertices" ));
 
 		blk = iSkinPart;
 	}
 
-	return nif->getIndex( nif->getIndex( blk, "Vertex Data" ).child( idx, 0 ), "Vertex" );
+	return nif->getIndex( nif->index(idx, 0, nif->getIndex( blk, "Vertex Data" )), "Vertex" );
 }
 
 
@@ -264,7 +264,7 @@ void BSShape::transform()
 
 			auto b = nif->getIndex( iSkinData, "Bone List" );
 			for ( int i = 0; i < weights.count(); i++ )
-				weights[i].setTransform( nif, b.child( i, 0 ) );
+				weights[i].setTransform( nif, nif->index( i, 0, b) );
 
 			isSkinned = weights.count();
 		}
@@ -621,14 +621,14 @@ void BSShape::drawSelection() const
 			int dataCt = nif->rowCount( data );
 
 			for ( int i = 0; i < dataCt; i++ ) {
-				auto d = data.child( i, 0 );
+				auto d = nif->index( i, 0, data );
 
 				int numC = nif->get<int>( d, "Num Combined" );
 				auto c = nif->getIndex( d, "Combined" );
 				int cCt = nif->rowCount( c );
 
 				for ( int j = 0; j < cCt; j++ ) {
-					idxs += nif->getIndex( c.child( j, 0 ), "Bounding Sphere" );
+					idxs += nif->getIndex( nif->index( j, 0, c ), "Bounding Sphere" );
 				}
 			}
 		}
@@ -638,10 +638,10 @@ void BSShape::drawSelection() const
 			return;
 		}
 
-		Vector3 pTrans = nif->get<Vector3>( pBlock.child( 1, 0 ), "Translation" );
+		Vector3 pTrans = nif->get<Vector3>( nif->index( 1, 0, pBlock ), "Translation" );
 		auto iBSphere = nif->getIndex( pBlock, "Bounding Sphere" );
-		Vector3 pbvC = nif->get<Vector3>( iBSphere.child( 0, 2 ) );
-		float pbvR = nif->get<float>( iBSphere.child( 1, 2 ) );
+		Vector3 pbvC = nif->get<Vector3>( nif->index( 0, 2, iBSphere ) );
+		float pbvR = nif->get<float>( nif->index( 1, 2, iBSphere ) );
 
 		if ( pbvR > 0.0 ) {
 			glColor4f( 0, 1, 0, 0.33 );
@@ -652,7 +652,7 @@ void BSShape::drawSelection() const
 
 		for ( auto i : idxs ) {
 			// Transform compound
-			auto iTrans = i.parent().child( 1, 0 );
+			auto iTrans = nif->index( 1, 0, i.parent() );
 			Matrix mat = nif->get<Matrix>( iTrans, "Rotation" );
 			//auto trans = nif->get<Vector3>( iTrans, "Translation" );
 			float scale = nif->get<float>( iTrans, "Scale" );
@@ -797,9 +797,9 @@ void BSShape::drawSelection() const
 		for ( int l = 0; l < loopNum; l++ ) {
 
 			if ( n != "Num Primitives" && !isSubSegArray && !isSegmentArray ) {
-				sidx = idx.child( 1, 0 );
+				sidx = nif->index( 1, 0, idx );
 			} else if ( isSegmentArray ) {
-				sidx = idx.child( l, 0 ).child( 1, 0 );
+				sidx = nif->index( 1, 0, nif->index( l, 0,idx ) );
 			}
 			s = sidx.row() + o;
 
@@ -809,13 +809,13 @@ void BSShape::drawSelection() const
 
 			auto recs = sidx.sibling( s + 3, 0 );
 			for ( int i = 0; i < numRec; i++ ) {
-				auto subrec = recs.child( i, 0 );
+				auto subrec = nif->index( i, 0, recs );
 				int o = 0;
 				if ( subrec.data( Qt::DisplayRole ).toString() != "Sub Segment" )
 					o = 3; // Offset 3 rows for < 130 BSGeometrySegmentData
 
-				auto suboff = subrec.child( o, 2 ).data().toInt() / 3;
-				auto subcnt = subrec.child( o + 1, 2 ).data().toInt();
+				auto suboff = nif->index( o, 2, subrec ).data().toInt() / 3;
+				auto subcnt = nif->index( o + 1, 2, subrec ).data().toInt();
 
 				for ( int j = suboff; j < subcnt + suboff; j++ ) {
 					if ( j >= maxTris )
@@ -861,7 +861,7 @@ void BSShape::drawSelection() const
 			int ct = nif->rowCount( iBones );
 
 			for ( int i = 0; i < ct; i++ ) {
-				auto b = iBones.child( i, 0 );
+				auto b = nif->index( i, 0, iBones );
 				boneSphere( nif, b );
 			}
 		}
@@ -873,7 +873,7 @@ void BSShape::drawSelection() const
 	if ( n == "Bone List" ) {
 		if ( nif->isArray( idx ) ) {
 			for ( int i = 0; i < nif->rowCount( idx ); i++ )
-				boneSphere( nif, idx.child( i, 0 ) );
+				boneSphere( nif, nif->index( i, 0, idx ) );
 		} else {
 			boneSphere( nif, idx );
 		}

--- a/src/gl/controllers.cpp
+++ b/src/gl/controllers.cpp
@@ -68,7 +68,7 @@ bool ControllerManager::update( const NifModel * nif, const QModelIndex & index 
 						QModelIndex iTags = nif->getIndex( iKeys, "Text Keys" );
 
 						for ( int r = 0; r < nif->rowCount( iTags ); r++ ) {
-							tags.insert( nif->get<QString>( iTags.child( r, 0 ), "Value" ), nif->get<float>( iTags.child( r, 0 ), "Time" ) );
+							tags.insert( nif->get<QString>( nif->index(r, 0, iTags), "Value" ), nif->get<float>( nif->index( r, 0, iTags ), "Time" ) );
 						}
 
 						scene->animTags[name] = tags;
@@ -109,7 +109,7 @@ void ControllerManager::setSequence( const QString & seqname )
 				QModelIndex iCtrlBlcks = nif->getIndex( iSeq, "Controlled Blocks" );
 
 				for ( int r = 0; r < nif->rowCount( iCtrlBlcks ); r++ ) {
-					QModelIndex iCB = iCtrlBlcks.child( r, 0 );
+					QModelIndex iCB = nif->index(r, 0, iCtrlBlcks);
 
 					QModelIndex iInterp = nif->getBlock( nif->getLink( iCB, "Interpolator" ), "NiInterpolator" );
 
@@ -455,16 +455,16 @@ bool MorphController::update( const NifModel * nif, const QModelIndex & index )
 				iInterpolatorWeights = nif->getIndex( iBlock, "Interpolator Weights" );
 			}
 
-			QModelIndex iKey = midx.child( r, 0 );
+			QModelIndex iKey = nif->index( r, 0, midx );
 
 			MorphKey * key = new MorphKey;
 			key->index = 0;
 
 			// this is ugly...
 			if ( iInterpolators.isValid() ) {
-				key->iFrames = nif->getIndex( nif->getBlock( nif->getLink( nif->getBlock( nif->getLink( iInterpolators.child( r, 0 ) ), "NiFloatInterpolator" ), "Data" ), "NiFloatData" ), "Data" );
+				key->iFrames = nif->getIndex( nif->getBlock( nif->getLink( nif->getBlock( nif->getLink( nif->index( r, 0, iInterpolators ) ), "NiFloatInterpolator" ), "Data" ), "NiFloatData" ), "Data" );
 			} else if ( iInterpolatorWeights.isValid() ) {
-				key->iFrames = nif->getIndex( nif->getBlock( nif->getLink( nif->getBlock( nif->getLink( iInterpolatorWeights.child( r, 0 ), "Interpolator" ), "NiFloatInterpolator" ), "Data" ), "NiFloatData" ), "Data" );
+				key->iFrames = nif->getIndex( nif->getBlock( nif->getLink( nif->getBlock( nif->getLink( nif->index( r, 0, iInterpolatorWeights ), "Interpolator" ), "NiFloatInterpolator" ), "Data" ), "NiFloatData" ), "Data" );
 			} else {
 				key->iFrames = iKey;
 			}
@@ -503,7 +503,7 @@ void UVController::updateTime( float time )
 
 	if ( uvGroups.isValid() ) {
 		for ( int i = 0; i < 4 && i < nif->rowCount( uvGroups ); i++ ) {
-			interpolate( val[i], uvGroups.child( i, 0 ), ctrlTime( time ), luv );
+			interpolate( val[i], nif->index( i, 0, uvGroups ), ctrlTime( time ), luv );
 		}
 
 		// adjust coords; verified in SceneImmerse
@@ -598,11 +598,11 @@ bool ParticleController::update( const NifModel * nif, const QModelIndex & index
 			//{
 			for ( int p = 0; p < numValid && p < nif->rowCount( iParticles ); p++ ) {
 				Particle particle;
-				particle.velocity = nif->get<Vector3>( iParticles.child( p, 0 ), "Velocity" );
-				particle.lifetime = nif->get<float>( iParticles.child( p, 0 ), "Lifetime" );
-				particle.lifespan = nif->get<float>( iParticles.child( p, 0 ), "Lifespan" );
-				particle.lasttime = nif->get<float>( iParticles.child( p, 0 ), "Timestamp" );
-				particle.vertex = nif->get<int>( iParticles.child( p, 0 ), "Vertex ID" );
+				particle.velocity = nif->get<Vector3>( nif->index( p, 0, iParticles ), "Velocity" );
+				particle.lifetime = nif->get<float>( nif->index( p, 0, iParticles ), "Lifetime" );
+				particle.lifespan = nif->get<float>( nif->index( p, 0, iParticles ), "Lifespan" );
+				particle.lasttime = nif->get<float>( nif->index( p, 0, iParticles ), "Timestamp" );
+				particle.vertex = nif->get<int>( nif->index( p, 0, iParticles ), "Vertex ID" );
 				// Display saved particle start on initial load
 				list.append( particle );
 			}
@@ -888,9 +888,9 @@ void TexFlipController::updateTime( float time )
 
 	// TexturingProperty
 	if ( target ) {
-		target->textures[flipSlot & 7].iSource = nif->getBlock( nif->getLink( iSources.child( (int)r, 0 ) ), "NiSourceTexture" );
+		target->textures[flipSlot & 7].iSource = nif->getBlock( nif->getLink( nif->index( (int)r, 0, iSources ) ), "NiSourceTexture" );
 	} else if ( oldTarget ) {
-		oldTarget->iImage = nif->getBlock( nif->getLink( iSources.child( (int)r, 0 ) ), "NiImage" );
+		oldTarget->iImage = nif->getBlock( nif->getLink( nif->index( (int)r, 0, iSources ) ), "NiImage" );
 	}
 }
 

--- a/src/gl/glcontroller.cpp
+++ b/src/gl/glcontroller.cpp
@@ -296,14 +296,14 @@ bool Controller::timeIndex( float time, const NifModel * nif, const QModelIndex 
 	int count;
 
 	if ( array.isValid() && ( count = nif->rowCount( array ) ) > 0 ) {
-		if ( time <= nif->get<float>( array.child( 0, 0 ), "Time" ) ) {
+		if ( time <= nif->get<float>( nif->index( 0, 0, array ), "Time" ) ) {
 			i = j = 0;
 			x = 0.0;
 
 			return true;
 		}
 
-		if ( time >= nif->get<float>( array.child( count - 1, 0 ), "Time" ) ) {
+		if ( time >= nif->get<float>( nif->index( count - 1, 0, array ), "Time" ) ) {
 			i = j = count - 1;
 			x = 0.0;
 
@@ -313,13 +313,13 @@ bool Controller::timeIndex( float time, const NifModel * nif, const QModelIndex 
 		if ( i < 0 || i >= count )
 			i = 0;
 
-		float tI = nif->get<float>( array.child( i, 0 ), "Time" );
+		float tI = nif->get<float>( nif->index( i, 0, array ), "Time" );
 
 		if ( time > tI ) {
 			j = i + 1;
 			float tJ;
 
-			while ( time >= ( tJ = nif->get<float>( array.child( j, 0 ), "Time" ) ) ) {
+			while ( time >= ( tJ = nif->get<float>( nif->index( j, 0, array ), "Time" ) ) ) {
 				i  = j++;
 				tI = tJ;
 			}
@@ -331,7 +331,7 @@ bool Controller::timeIndex( float time, const NifModel * nif, const QModelIndex 
 			j = i - 1;
 			float tJ;
 
-			while ( time <= ( tJ = nif->get<float>( array.child( j, 0 ), "Time" ) ) ) {
+			while ( time <= ( tJ = nif->get<float>( nif->index( j, 0, array ), "Time" ) ) ) {
 				i  = j--;
 				tI = tJ;
 			}
@@ -375,8 +375,8 @@ template <typename T> bool interpolate( T & value, const QModelIndex & array, fl
 		float x;
 
 		if ( Controller::timeIndex( time, nif, frames, last, next, x ) ) {
-			T v1 = nif->get<T>( frames.child( last, 0 ), "Value" );
-			T v2 = nif->get<T>( frames.child( next, 0 ), "Value" );
+			T v1 = nif->get<T>( nif->index( last, 0, frames ), "Value" );
+			T v2 = nif->get<T>( nif->index( next, 0, frames ), "Value" );
 
 			switch ( nif->get<int>( array, "Interpolation" ) ) {
 			
@@ -390,9 +390,9 @@ template <typename T> bool interpolate( T & value, const QModelIndex & array, fl
 				*/
 
 				// Tangent 1
-				float t1 = nif->get<float>( frames.child( last, 0 ), "Backward" );
+				float t1 = nif->get<float>( nif->index( last, 0, frames ), "Backward" );
 				// Tangent 2
-				float t2 = nif->get<float>( frames.child( next, 0 ), "Forward" );
+				float t2 = nif->get<float>( nif->index( next, 0, frames ), "Forward" );
 
 				float x2 = x * x;
 				float x3 = x2 * x;
@@ -452,7 +452,7 @@ template <> bool Controller::interpolate( bool & value, const QModelIndex & arra
 		QModelIndex frames = nif->getIndex( array, "Keys" );
 
 		if ( timeIndex( time, nif, frames, last, next, x ) ) {
-			value = nif->get<int>( frames.child( last, 0 ), "Value" );
+			value = nif->get<int>( nif->index( last, 0, frames ), "Value" );
 
 			return true;
 		}
@@ -478,7 +478,7 @@ template <> bool Controller::interpolate( Matrix & value, const QModelIndex & ar
 
 					for ( int s = 0; s < 3 && s < nif->rowCount( subkeys ); s++ ) {
 						r[s] = 0;
-						interpolate( r[s], subkeys.child( s, 0 ), time, last );
+						interpolate( r[s], nif->index( s, 0, subkeys ), time, last );
 					}
 
 					value = Matrix::euler( 0, 0, r[2] ) * Matrix::euler( 0, r[1], 0 ) * Matrix::euler( r[0], 0, 0 );
@@ -492,8 +492,8 @@ template <> bool Controller::interpolate( Matrix & value, const QModelIndex & ar
 				QModelIndex frames = nif->getIndex( array, "Quaternion Keys" );
 
 				if ( timeIndex( time, nif, frames, last, next, x ) ) {
-					Quat v1 = nif->get<Quat>( frames.child( last, 0 ), "Value" );
-					Quat v2 = nif->get<Quat>( frames.child( next, 0 ), "Value" );
+					Quat v1 = nif->get<Quat>( nif->index( last, 0, frames ), "Value" );
+					Quat v2 = nif->get<Quat>( nif->index( next, 0, frames ), "Value" );
 
 					if ( Quat::dotproduct( v1, v2 ) < 0 )
 						v1.negate(); // don't take the long path
@@ -549,7 +549,7 @@ struct qarray
 
 	T operator[]( uint index ) const
 	{
-		return nif_->get<T>( array_.child( index + off_, 0 ) );
+		return nif_->get<T>( nif_->index( index + off_, 0, array_ ) );
 	}
 	const NifModel * nif_;
 	const QModelIndex & array_;

--- a/src/gl/glnode.cpp
+++ b/src/gl/glnode.cpp
@@ -319,7 +319,7 @@ void Node::update( const NifModel * nif, const QModelIndex & index )
 
 		if ( iChildren.isValid() ) {
 			for ( int c = 0; c < nif->rowCount( iChildren ); c++ ) {
-				qint32 link = nif->getLink( iChildren.child( c, 0 ) );
+				qint32 link = nif->getLink( nif->index( c, 0, iChildren ) );
 
 				if ( lChildren.contains( link ) ) {
 					QModelIndex iChild = nif->getBlock( link );
@@ -643,7 +643,7 @@ void Node::drawSelection() const
 
 		int ct = nif->rowCount( cp );
 		for ( int i = 0; i < ct; i++ ) {
-			auto p = cp.child( i, 0 );
+			auto p = nif->index( i, 0, cp );
 
 			auto trans = nif->get<Vector3>( p, "Translation" );
 			auto rot = nif->get<Quat>( p, "Rotation" );
@@ -792,7 +792,7 @@ void drawHvkShape( const NifModel * nif, const QModelIndex & iShape, QStack<QMod
 		if ( iShapes.isValid() ) {
 			for ( int r = 0; r < nif->rowCount( iShapes ); r++ ) {
 				if ( !Node::SELECTING ) {
-					if ( scene->currentBlock == nif->getBlock( nif->getLink( iShapes.child( r, 0 ) ) ) ) {
+					if ( scene->currentBlock == nif->getBlock( nif->getLink( nif->index( r, 0, iShapes ) ) ) ) {
 						// fix: add selected visual to havok meshes
 						glHighlightColor();
 						glLineWidth( 2.5 );
@@ -805,7 +805,7 @@ void drawHvkShape( const NifModel * nif, const QModelIndex & iShape, QStack<QMod
 					}
 				}
 
-				drawHvkShape( nif, nif->getBlock( nif->getLink( iShapes.child( r, 0 ) ) ), stack, scene, origin_color3fv );
+				drawHvkShape( nif, nif->getBlock( nif->getLink( nif->index( r, 0, iShapes ) ) ), stack, scene, origin_color3fv );
 			}
 		}
 	} else if ( name == "bhkTransformShape" || name == "bhkConvexTransformShape" ) {
@@ -836,7 +836,7 @@ void drawHvkShape( const NifModel * nif, const QModelIndex & iShape, QStack<QMod
 		QModelIndex iSpheres = nif->getIndex( iShape, "Spheres" );
 
 		for ( int r = 0; r < nif->rowCount( iSpheres ); r++ ) {
-			drawSphere( nif->get<Vector3>( iSpheres.child( r, 0 ), "Center" ), nif->get<float>( iSpheres.child( r, 0 ), "Radius" ) );
+			drawSphere( nif->get<Vector3>( nif->index( r, 0, iSpheres ), "Center" ), nif->get<float>( nif->index( r, 0, iSpheres ), "Radius" ) );
 		}
 	} else if ( name == "bhkBoxShape" ) {
 		if ( Node::SELECTING ) {
@@ -917,7 +917,7 @@ void drawHvkShape( const NifModel * nif, const QModelIndex & iShape, QStack<QMod
 			QModelIndex iTris = nif->getIndex( iData, "Triangles" );
 
 			for ( int t = 0; t < nif->rowCount( iTris ); t++ ) {
-				Triangle tri = nif->get<Triangle>( iTris.child( t, 0 ), "Triangle" );
+				Triangle tri = nif->get<Triangle>( nif->index( t, 0, iTris ), "Triangle" );
 
 				if ( tri[0] != tri[1] || tri[1] != tri[2] || tri[2] != tri[0] ) {
 					glBegin( GL_LINE_STRIP );
@@ -948,9 +948,9 @@ void drawHvkShape( const NifModel * nif, const QModelIndex & iShape, QStack<QMod
 						glHighlightColor();
 
 						//for ( int t = 0; t < nif->rowCount( iTris ); t++ )
-						//	DrawTriangleIndex( verts, nif->get<Triangle>( iTris.child( t, 0 ), "Triangle" ), t );
+						//	DrawTriangleIndex( verts, nif->get<Triangle>( nif->index( t, 0, iTris ), "Triangle" ), t );
 					} else if ( nif->isCompound( nif->getBlockType( scene->currentIndex ) ) ) {
-						Triangle tri = nif->get<Triangle>( iTris.child( i, 0 ), "Triangle" );
+						Triangle tri = nif->get<Triangle>( nif->index( i, 0, iTris ), "Triangle" );
 						DrawTriangleSelection( verts, tri );
 						//DrawTriangleIndex( verts, tri, i );
 					} else if ( nif->getBlockName( scene->currentIndex ) == "Normal" ) {
@@ -975,7 +975,7 @@ void drawHvkShape( const NifModel * nif, const QModelIndex & iShape, QStack<QMod
 						QModelIndex iParent = scene->currentIndex.parent();
 						int rowCount = nif->rowCount( iParent );
 						for ( int j = 0; j < i; j++ ) {
-							totalVerts += nif->get<int>( iParent.child( j, 0 ), "Num Vertices" );
+							totalVerts += nif->get<int>( nif->index( j, 0, iParent ), "Num Vertices" );
 						}
 
 						end_vertex += totalVerts + num_vertices;
@@ -985,7 +985,7 @@ void drawHvkShape( const NifModel * nif, const QModelIndex & iShape, QStack<QMod
 					}
 
 					for ( int t = 0; t < nif->rowCount( iTris ); t++ ) {
-						Triangle tri = nif->get<Triangle>( iTris.child( t, 0 ), "Triangle" );
+						Triangle tri = nif->get<Triangle>( nif->index( t, 0, iTris ), "Triangle" );
 
 						if ( (start_vertex <= tri[0]) && (tri[0] < end_vertex) ) {
 							if ( (start_vertex <= tri[1]) && (tri[1] < end_vertex) && (start_vertex <= tri[2]) && (tri[2] < end_vertex) ) {
@@ -1020,7 +1020,7 @@ void drawHvkShape( const NifModel * nif, const QModelIndex & iShape, QStack<QMod
 					int end_vertex = 0;
 
 					for ( int subshape = 0; subshape < nif->rowCount( iSubShapes ); subshape++ ) {
-						QModelIndex iCurrentSubShape = iSubShapes.child( subshape, 0 );
+						QModelIndex iCurrentSubShape = nif->index( subshape, 0, iSubShapes );
 						int num_vertices = nif->get<int>( iCurrentSubShape, "Num Vertices" );
 						//qDebug() << num_vertices;
 						end_vertex += num_vertices;
@@ -1034,7 +1034,7 @@ void drawHvkShape( const NifModel * nif, const QModelIndex & iShape, QStack<QMod
 
 					// highlight the triangles of the subshape
 					for ( int t = 0; t < nif->rowCount( iTris ); t++ ) {
-						Triangle tri = nif->get<Triangle>( iTris.child( t, 0 ), "Triangle" );
+						Triangle tri = nif->get<Triangle>( nif->index( t, 0, iTris ), "Triangle" );
 
 						if ( (start_vertex <= tri[0]) && (tri[0] < end_vertex) ) {
 							if ( (start_vertex <= tri[1]) && (tri[1] < end_vertex) && (start_vertex <= tri[2]) && (tri[2] < end_vertex) ) {
@@ -1090,7 +1090,7 @@ void drawHvkConstraint( const NifModel * nif, const QModelIndex & iConstraint, c
 	}
 
 	for ( int r = 0; r < nif->rowCount( iBodies ); r++ ) {
-		qint32 l = nif->getLink( iBodies.child( r, 0 ) );
+		qint32 l = nif->getLink( nif->index( r, 0, iBodies ) );
 
 		if ( !scene->bhkBodyTrans.contains( l ) )
 			return; // TODO: Make sure this is not supposed to be continue;
@@ -1503,7 +1503,7 @@ void Node::drawHavok()
 
 	if ( iExtraDataList.isValid() ) {
 		for ( int d = 0; d < nif->rowCount( iExtraDataList ); d++ ) {
-			QModelIndex iBound = nif->getBlock( nif->getLink( iExtraDataList.child( d, 0 ) ), "BSBound" );
+			QModelIndex iBound = nif->getBlock( nif->getLink( nif->index( d, 0, iExtraDataList ) ), "BSBound" );
 
 			if ( !iBound.isValid() )
 				continue;
@@ -1841,7 +1841,7 @@ void Node::drawFurn()
 
 	for ( int p = 0; p < nif->rowCount( iExtraDataList ); p++ ) {
 		// DONE: never seen Furn in nifs, so there may be a need of a fix here later - saw one, fixed a bug
-		QModelIndex iFurnMark = nif->getBlock( nif->getLink( iExtraDataList.child( p, 0 ) ), "BSFurnitureMarker" );
+		QModelIndex iFurnMark = nif->getBlock( nif->getLink( nif->index( p, 0, iExtraDataList ) ), "BSFurnitureMarker" );
 
 		if ( !iFurnMark.isValid() )
 			continue;
@@ -1852,7 +1852,7 @@ void Node::drawFurn()
 			break;
 
 		for ( int j = 0; j < nif->rowCount( iPositions ); j++ ) {
-			QModelIndex iPosition = iPositions.child( j, 0 );
+			QModelIndex iPosition = nif->index( j, 0, iPositions );
 
 			if ( scene->currentIndex == iPosition )
 				glHighlightColor();
@@ -1943,7 +1943,7 @@ BoundSphere Node::bounds() const
 
 	if ( iExtraDataList.isValid() ) {
 		for ( int d = 0; d < nif->rowCount( iExtraDataList ); d++ ) {
-			QModelIndex iBound = nif->getBlock( nif->getLink( iExtraDataList.child( d, 0 ) ), "BSBound" );
+			QModelIndex iBound = nif->getBlock( nif->getLink( nif->index( d, 0, iExtraDataList ) ), "BSBound" );
 
 			if ( !iBound.isValid() )
 				continue;
@@ -1988,8 +1988,8 @@ void LODNode::update( const NifModel * nif, const QModelIndex & index )
 
 		if ( iLevels.isValid() ) {
 			for ( int r = 0; r < nif->rowCount( iLevels ); r++ ) {
-				ranges.append( { nif->get<float>( iLevels.child( r, 0 ), "Near Extent" ),
-				                 nif->get<float>( iLevels.child( r, 0 ), "Far Extent" ) }
+				ranges.append( { nif->get<float>( nif->index( r, 0, iLevels ), "Near Extent" ),
+				                 nif->get<float>( nif->index( r, 0, iLevels ), "Far Extent" ) }
 				);
 			}
 		}

--- a/src/gl/glproperty.cpp
+++ b/src/gl/glproperty.cpp
@@ -155,7 +155,7 @@ void PropertyList::del( Property * p )
 	if ( !p )
 		return;
 
-	QHash<Property::Type, Property *>::iterator i = properties.find( p->type() );
+	QMultiHash<Property::Type, Property *>::iterator i = properties.find( p->type() );
 
 	while ( p && i != properties.end() && i.key() == p->type() ) {
 		if ( i.value() == p ) {
@@ -1011,7 +1011,7 @@ QString BSShaderLightingProperty::fileName( int id ) const
 		QModelIndex iTextures = nif->getIndex( iTextureSet, "Textures" );
 
 		if ( id >= 0 && id < nTextures )
-			return nif->get<QString>( iTextures.child( id, 0 ) );
+			return nif->get<QString>( nif->index( id, 0, iTextures ) );
 	} else {
 		// handle niobject name="BSEffectShaderProperty...
 		auto m = static_cast<EffectMaterial *>(material);

--- a/src/gl/gltexloaders.cpp
+++ b/src/gl/gltexloaders.cpp
@@ -666,7 +666,7 @@ bool texLoad( const QModelIndex & iData, QString & texformat, GLenum & target, G
 		QModelIndex iMipmaps = nif->getIndex( iData, "Mipmaps" );
 
 		if ( mipmaps > 0 && iMipmaps.isValid() ) {
-			QModelIndex iMipmap = iMipmaps.child( 0, 0 );
+			QModelIndex iMipmap = nif->index( 0, 0, iMipmaps );
 			width  = nif->get<uint>( iMipmap, "Width" );
 			height = nif->get<uint>( iMipmap, "Height" );
 		}
@@ -683,7 +683,7 @@ bool texLoad( const QModelIndex & iData, QString & texformat, GLenum & target, G
 		QModelIndex iPixelData = nif->getIndex( iData, "Pixel Data" );
 
 		if ( iPixelData.isValid() ) {
-			if ( QByteArray * pdata = nif->get<QByteArray *>( iPixelData.child(0, 0) ) ) {
+			if ( QByteArray * pdata = nif->get<QByteArray *>( nif->index(0, 0, iPixelData) ) ) {
 				buf.setData( *pdata );
 				buf.open( QIODevice::ReadOnly );
 				buf.seek( 0 );
@@ -707,7 +707,7 @@ bool texLoad( const QModelIndex & iData, QString & texformat, GLenum & target, G
 
 			if ( iChannels.isValid() ) {
 				for ( int i = 0; i < 4; i++ ) {
-					QModelIndex iChannel = iChannels.child( i, 0 );
+					QModelIndex iChannel = nif->index( i, 0, iChannels );
 					uint type = nif->get<uint>( iChannel, "Type" );
 					uint bpc  = nif->get<uint>( iChannel, "Bits Per Channel" );
 					int m = (1 << bpc) - 1;
@@ -769,7 +769,7 @@ bool texLoad( const QModelIndex & iData, QString & texformat, GLenum & target, G
 
 					if ( nmap > 0 && iPaletteArray.isValid() ) {
 						for ( uint i = 0; i < nmap; ++i ) {
-							auto color = nif->get<ByteColor4>( iPaletteArray.child( i, 0 ) ).toQColor();
+							auto color = nif->get<ByteColor4>( nif->index( i, 0, iPaletteArray ) ).toQColor();
 							quint8 r = color.red();
 							quint8 g = color.green();
 							quint8 b = color.blue();
@@ -1219,7 +1219,7 @@ bool texSaveDDS( const QModelIndex & index, const QString & filepath, const GLui
 	QModelIndex iPixelData = nif->getIndex( index, "Pixel Data" );
 
 	if ( iPixelData.isValid() ) {
-		if ( QByteArray * pdata = nif->get<QByteArray *>( iPixelData.child( 0, 0 ) ) ) {
+		if ( QByteArray * pdata = nif->get<QByteArray *>( nif->index( 0, 0, iPixelData ) ) ) {
 			buf.setData( *pdata );
 			buf.open( QIODevice::ReadOnly );
 			buf.seek( 0 );
@@ -1399,7 +1399,7 @@ bool texSaveDDS( const QModelIndex & index, const QString & filepath, const GLui
 
 		if ( iChannels.isValid() ) {
 			for ( int i = 0; i < 4; i++ ) {
-				QModelIndex iChannel = iChannels.child( i, 0 );
+				QModelIndex iChannel = nif->index( i, 0, iChannels );
 				uint type = nif->get<uint>( iChannel, "Type" );
 				uint bpc  = nif->get<uint>( iChannel, "Bits Per Channel" );
 				int m = (1 << bpc) - 1;
@@ -1617,7 +1617,7 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 			QModelIndex fastCompareDest = nif->getIndex( iData, "Old Fast Compare" );
 
 			for ( int i = 0; i < pix.rowCount( fastCompareSrc ); i++ ) {
-				nif->set<quint8>( fastCompareDest.child( i, 0 ), pix.get<quint8>( fastCompareSrc.child( i, 0 ) ) );
+				nif->set<quint8>( nif->index( i, 0, fastCompareDest ), pix.get<quint8>( nif->index( i, 0, fastCompareSrc ) ) );
 			}
 
 			if ( nif->checkVersion( 0x0A010000, 0x0A020000 ) && pix.checkVersion( 0x0A010000, 0x0A020000 ) ) {
@@ -1640,15 +1640,15 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 			// copy channels
 			for ( int i = 0; i < 4; i++ ) {
 				qDebug() << "Channel" << i;
-				qDebug() << pix.get<quint32>( srcChannels.child( i, 0 ), "Type" );
-				qDebug() << pix.get<quint32>( srcChannels.child( i, 0 ), "Convention" );
-				qDebug() << pix.get<quint8>( srcChannels.child( i, 0 ), "Bits Per Channel" );
-				qDebug() << pix.get<quint8>( srcChannels.child( i, 0 ), "Is Signed" );
+				qDebug() << pix.get<quint32>( nif->index( i, 0, srcChannels ), "Type" );
+				qDebug() << pix.get<quint32>( nif->index( i, 0, srcChannels ), "Convention" );
+				qDebug() << pix.get<quint8>( nif->index( i, 0, srcChannels ), "Bits Per Channel" );
+				qDebug() << pix.get<quint8>( nif->index( i, 0, srcChannels ), "Is Signed" );
 
-				nif->set<quint32>( destChannels.child( i, 0 ), "Type", pix.get<quint32>( srcChannels.child( i, 0 ), "Type" ) );
-				nif->set<quint32>( destChannels.child( i, 0 ), "Convention", pix.get<quint32>( srcChannels.child( i, 0 ), "Convention" ) );
-				nif->set<quint8>( destChannels.child( i, 0 ), "Bits Per Channel", pix.get<quint8>( srcChannels.child( i, 0 ), "Bits Per Channel" ) );
-				nif->set<quint8>( destChannels.child( i, 0 ), "Is Signed", pix.get<quint8>( srcChannels.child( i, 0 ), "Is Signed" ) );
+				nif->set<quint32>( nif->index( i, 0, destChannels ), "Type", pix.get<quint32>( nif->index( i, 0, srcChannels ), "Type" ) );
+				nif->set<quint32>( nif->index( i, 0, destChannels ), "Convention", pix.get<quint32>( nif->index( i, 0, srcChannels ), "Convention" ) );
+				nif->set<quint8>( nif->index( i, 0, destChannels ), "Bits Per Channel", pix.get<quint8>( nif->index( i, 0, srcChannels ), "Bits Per Channel" ) );
+				nif->set<quint8>( nif->index( i, 0, destChannels ), "Is Signed", pix.get<quint8>( nif->index( i, 0, srcChannels ), "Is Signed" ) );
 			}
 
 			nif->set<quint32>( iData, "Num Faces", pix.get<quint32>( iPixData, "Num Faces" ) );
@@ -1672,9 +1672,9 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 		nif->updateArray( destMipMaps );
 
 		for ( int i = 0; i < pix.rowCount( srcMipMaps ); i++ ) {
-			nif->set<quint32>( destMipMaps.child( i, 0 ), "Width", pix.get<quint32>( srcMipMaps.child( i, 0 ), "Width" ) );
-			nif->set<quint32>( destMipMaps.child( i, 0 ), "Height", pix.get<quint32>( srcMipMaps.child( i, 0 ), "Height" ) );
-			nif->set<quint32>( destMipMaps.child( i, 0 ), "Offset", pix.get<quint32>( srcMipMaps.child( i, 0 ), "Offset" ) );
+			nif->set<quint32>( nif->index( i, 0, destMipMaps ), "Width", pix.get<quint32>( nif->index( i, 0, srcMipMaps ), "Width" ) );
+			nif->set<quint32>( nif->index( i, 0, destMipMaps ), "Height", pix.get<quint32>( nif->index( i, 0, srcMipMaps ), "Height" ) );
+			nif->set<quint32>( nif->index( i, 0, destMipMaps ), "Offset", pix.get<quint32>( nif->index( i, 0, srcMipMaps ), "Offset" ) );
 		}
 
 		nif->set<quint32>( iData, "Num Pixels", pix.get<quint32>( iPixData, "Num Pixels" ) );
@@ -1683,8 +1683,8 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 		QModelIndex destPixelData = nif->getIndex( iData, "Pixel Data" );
 
 		for ( int i = 0; i < pix.rowCount( srcPixelData ); i++ ) {
-			nif->updateArray( destPixelData.child( i, 0 ) );
-			nif->set<QByteArray>( destPixelData.child( i, 0 ), "Pixel Data", pix.get<QByteArray>( srcPixelData.child( i, 0 ), "Pixel Data" ) );
+			nif->updateArray( nif->index( i, 0, destPixelData ) );
+			nif->set<QByteArray>( nif->index( i, 0, destPixelData ), "Pixel Data", pix.get<QByteArray>( nif->index( i, 0, srcPixelData ), "Pixel Data" ) );
 		}
 
 		//nif->set<>( iData, "", pix.get<>( iPixData, "" ) );
@@ -1718,7 +1718,7 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 			QModelIndex oldFastCompare = nif->getIndex( iData, "Old Fast Compare" );
 
 			for ( int i = 0; i < 8; i++ ) {
-				nif->set<quint8>( oldFastCompare.child( i, 0 ), unk8bytes32[i] );
+				nif->set<quint8>( nif->index( i, 0, oldFastCompare ), unk8bytes32[i] );
 			}
 		} else if ( nif->checkVersion( 0x14000004, 0 ) ) {
 			// set stuff
@@ -1727,10 +1727,10 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 			QModelIndex destChannels = nif->getIndex( iData, "Channels" );
 
 			for ( int i = 0; i < 4; i++ ) {
-				nif->set<quint32>( destChannels.child( i, 0 ), "Type", i );       // red, green, blue, alpha
-				nif->set<quint32>( destChannels.child( i, 0 ), "Convention", 0 ); // fixed
-				nif->set<quint8>( destChannels.child( i, 0 ), "Bits Per Channel", 8 );
-				nif->set<quint8>( destChannels.child( i, 0 ), "Is Signed", 0 );
+				nif->set<quint32>( nif->index( i, 0, destChannels ), "Type", i );       // red, green, blue, alpha
+				nif->set<quint32>( nif->index( i, 0, destChannels ), "Convention", 0 ); // fixed
+				nif->set<quint8>( nif->index( i, 0, destChannels ), "Bits Per Channel", 8 );
+				nif->set<quint8>( nif->index( i, 0, destChannels ), "Is Signed", 0 );
 			}
 		}
 
@@ -1747,9 +1747,9 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 
 		// generate sizes and copy mipmap to NIF
 		for ( uint i = 0; i < mipmaps; i++ ) {
-			nif->set<quint32>( destMipMaps.child( i, 0 ), "Width", mipmapWidth );
-			nif->set<quint32>( destMipMaps.child( i, 0 ), "Height", mipmapHeight );
-			nif->set<quint32>( destMipMaps.child( i, 0 ), "Offset", mipmapOffset );
+			nif->set<quint32>( nif->index( i, 0, destMipMaps ), "Width", mipmapWidth );
+			nif->set<quint32>( nif->index( i, 0, destMipMaps ), "Height", mipmapHeight );
+			nif->set<quint32>( nif->index( i, 0, destMipMaps ), "Offset", mipmapOffset );
 
 			quint32 mipmapSize = mipmapWidth * mipmapHeight * 4;
 
@@ -1847,9 +1847,9 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 
 			for ( int i = 0; i < 8; i++ ) {
 				if ( ddsHeader.ddspf.dwRGBBitCount == 24 ) {
-					nif->set<quint8>( oldFastCompare.child( i, 0 ), unk8bytes24[i] );
+					nif->set<quint8>( nif->index( i, 0, oldFastCompare ), unk8bytes24[i] );
 				} else if ( ddsHeader.ddspf.dwRGBBitCount == 32 ) {
-					nif->set<quint8>( oldFastCompare.child( i, 0 ), unk8bytes32[i] );
+					nif->set<quint8>( nif->index( i, 0, oldFastCompare ), unk8bytes32[i] );
 				}
 			}
 		} else if ( nif->checkVersion( 0x14000004, 0 ) ) {
@@ -1865,15 +1865,15 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 
 				for ( int i = 0; i < 4; i++ ) {
 					if ( i == 0 ) {
-						nif->set<quint32>( destChannels.child( i, 0 ), "Type", 4 );       // compressed
-						nif->set<quint32>( destChannels.child( i, 0 ), "Convention", 4 ); // compressed
+						nif->set<quint32>( nif->index( i, 0, destChannels ), "Type", 4 );       // compressed
+						nif->set<quint32>( nif->index( i, 0, destChannels ), "Convention", 4 ); // compressed
 					} else {
-						nif->set<quint32>( destChannels.child( i, 0 ), "Type", 19 );      // empty
-						nif->set<quint32>( destChannels.child( i, 0 ), "Convention", 5 ); // empty
+						nif->set<quint32>( nif->index( i, 0, destChannels ), "Type", 19 );      // empty
+						nif->set<quint32>( nif->index( i, 0, destChannels ), "Convention", 5 ); // empty
 					}
 
-					nif->set<quint8>( destChannels.child( i, 0 ), "Bits Per Channel", 0 );
-					nif->set<quint8>( destChannels.child( i, 0 ), "Is Signed", 1 );
+					nif->set<quint8>( nif->index( i, 0, destChannels ), "Bits Per Channel", 0 );
+					nif->set<quint8>( nif->index( i, 0, destChannels ), "Is Signed", 1 );
 				}
 			} else {
 				nif->set<uint>( iData, "Bits Per Pixel", ddsHeader.ddspf.dwRGBBitCount );
@@ -1882,32 +1882,32 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 				for ( int i = 0; i < 3; i++ ) {
 					if ( ddsHeader.ddspf.dwRBitMask == RGBA_INV_MASK[i] ) {
 						//qDebug() << "red channel" << i;
-						nif->set<quint32>( destChannels.child( i, 0 ), "Type", 0 );
+						nif->set<quint32>( nif->index( i, 0, destChannels ), "Type", 0 );
 					} else if ( ddsHeader.ddspf.dwGBitMask == RGBA_INV_MASK[i] ) {
 						//qDebug() << "green channel" << i;
-						nif->set<quint32>( destChannels.child( i, 0 ), "Type", 1 );
+						nif->set<quint32>( nif->index( i, 0, destChannels ), "Type", 1 );
 					} else if ( ddsHeader.ddspf.dwBBitMask == RGBA_INV_MASK[i] ) {
 						//qDebug() << "blue channel" << i;
-						nif->set<quint32>( destChannels.child( i, 0 ), "Type", 2 );
+						nif->set<quint32>( nif->index( i, 0, destChannels ), "Type", 2 );
 					}
 				}
 
 				for ( int i = 0; i < 3; i++ ) {
-					nif->set<quint32>( destChannels.child( i, 0 ), "Convention", 0 ); // fixed
-					nif->set<quint8>( destChannels.child( i, 0 ), "Bits Per Channel", 8 );
-					nif->set<quint8>( destChannels.child( i, 0 ), "Is Signed", 0 );
+					nif->set<quint32>( nif->index( i, 0, destChannels ), "Convention", 0 ); // fixed
+					nif->set<quint8>( nif->index( i, 0, destChannels ), "Bits Per Channel", 8 );
+					nif->set<quint8>( nif->index( i, 0, destChannels ), "Is Signed", 0 );
 				}
 
 				if ( ddsHeader.ddspf.dwRGBBitCount == 32 ) {
-					nif->set<quint32>( destChannels.child( 3, 0 ), "Type", 3 );       // alpha
-					nif->set<quint32>( destChannels.child( 3, 0 ), "Convention", 0 ); // fixed
-					nif->set<quint8>( destChannels.child( 3, 0 ), "Bits Per Channel", 8 );
-					nif->set<quint8>( destChannels.child( 3, 0 ), "Is Signed", 0 );
+					nif->set<quint32>( nif->index( 3, 0, destChannels ), "Type", 3 );       // alpha
+					nif->set<quint32>( nif->index( 3, 0, destChannels ), "Convention", 0 ); // fixed
+					nif->set<quint8>( nif->index( 3, 0, destChannels ), "Bits Per Channel", 8 );
+					nif->set<quint8>( nif->index( 3, 0, destChannels ), "Is Signed", 0 );
 				} else if ( ddsHeader.ddspf.dwRGBBitCount == 24 ) {
-					nif->set<quint32>( destChannels.child( 3, 0 ), "Type", 19 );      // empty
-					nif->set<quint32>( destChannels.child( 3, 0 ), "Convention", 5 ); // empty
-					nif->set<quint8>( destChannels.child( 3, 0 ), "Bits Per Channel", 0 );
-					nif->set<quint8>( destChannels.child( 3, 0 ), "Is Signed", 0 );
+					nif->set<quint32>( nif->index( 3, 0, destChannels ), "Type", 19 );      // empty
+					nif->set<quint32>( nif->index( 3, 0, destChannels ), "Convention", 5 ); // empty
+					nif->set<quint8>( nif->index( 3, 0, destChannels ), "Bits Per Channel", 0 );
+					nif->set<quint8>( nif->index( 3, 0, destChannels ), "Is Signed", 0 );
 				}
 			}
 		}
@@ -1925,9 +1925,9 @@ bool texSaveNIF( NifModel * nif, const QString & filepath, QModelIndex & iData )
 		int mipmapOffset = 0;
 
 		for ( quint32 i = 0; i < ddsHeader.dwMipMapCount; i++ ) {
-			nif->set<quint32>( destMipMaps.child( i, 0 ), "Width", mipmapWidth );
-			nif->set<quint32>( destMipMaps.child( i, 0 ), "Height", mipmapHeight );
-			nif->set<quint32>( destMipMaps.child( i, 0 ), "Offset", mipmapOffset );
+			nif->set<quint32>( nif->index( i, 0, destMipMaps ), "Width", mipmapWidth );
+			nif->set<quint32>( nif->index( i, 0, destMipMaps ), "Height", mipmapHeight );
+			nif->set<quint32>( nif->index( i, 0, destMipMaps ), "Offset", mipmapOffset );
 
 			if ( ddsHeader.ddspf.dwFlags & DDS_FOURCC ) {
 				if ( ddsHeader.ddspf.dwFourCC == FOURCC_DXT1 ) {

--- a/src/glview.h
+++ b/src/glview.h
@@ -35,7 +35,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "gl/glscene.h"
 
-#include <QGLWidget> // Inherited
+#include <QOpenGLWidget> // Inherited
 #include <QGraphicsView>
 #include <QDateTime>
 #include <QPersistentModelIndex>
@@ -56,7 +56,7 @@ class QTimer;
 
 
 //! The main [Viewport](@ref viewport_details) class
-class GLView final : public QGLWidget
+class GLView final : public QOpenGLWidget
 {
 	Q_OBJECT
 
@@ -64,7 +64,7 @@ class GLView final : public QGLWidget
 	friend class GLGraphicsView;
 
 private:
-	GLView( const QGLFormat & format, QWidget * parent, const QGLWidget * shareWidget = 0 );
+	GLView( const QGLFormat & format, QWidget * parent, const QOpenGLWidget * shareWidget = 0 );
 	~GLView();
 
 public:

--- a/src/lib/importex/3ds.cpp
+++ b/src/lib/importex/3ds.cpp
@@ -106,7 +106,7 @@ static void addLink( NifModel * nif, const QModelIndex & iBlock, const QString &
 	int numIndices = nif->get<int>( iSize );
 	nif->set<int>( iSize, numIndices + 1 );
 	nif->updateArray( iArray );
-	nif->setLink( iArray.child( numIndices, 0 ), link );
+	nif->setLink( nif->index( numIndices, 0, iArray ), link );
 }
 
 static Color3 GetColorFromChunk( Chunk * cnk )
@@ -244,7 +244,7 @@ void import3ds( NifModel * nif, const QModelIndex & index )
 	float ObjScale;
 	QVector<objMesh> ObjMeshes;
 	QMap<QString, objMaterial> ObjMaterials;
-	QMap<QString, objKfSequence> ObjKeyframes;
+	QMultiMap<QString, objKfSequence> ObjKeyframes;
 
 	QSettings settings;
 	settings.beginGroup( "Import-Export" );
@@ -559,7 +559,7 @@ void import3ds( NifModel * nif, const QModelIndex & index )
 				}
 			}
 
-			ObjKeyframes.insertMulti( newKfSeq.objectName, newKfSeq );
+			ObjKeyframes.insert( newKfSeq.objectName, newKfSeq );
 		}
 	}
 
@@ -718,8 +718,8 @@ void import3ds( NifModel * nif, const QModelIndex & index )
 			}
 
 			nif->updateArray( iTexCo );
-			nif->updateArray( iTexCo.child( 0, 0 ) );
-			nif->setArray<Vector2>( iTexCo.child( 0, 0 ),  mesh->texcoords );
+			nif->updateArray( nif->index( 0, 0, iTexCo ) );
+			nif->setArray<Vector2>( nif->index( 0, 0, iTexCo ),  mesh->texcoords );
 
 			nif->set<int>( iData, "Has Triangles", 1 );
 			nif->set<int>( iData, "Num Triangles", triangles.count() );

--- a/src/lib/importex/3ds.h
+++ b/src/lib/importex/3ds.h
@@ -223,7 +223,7 @@ public:
 
 	Chunk * getChild( ChunkType ct )
 	{
-		return c[ct];
+		return getChildren(ct)[ct];
 	}
 
 	void reset()
@@ -275,7 +275,7 @@ private:
 	ChunkDataLength dl;
 	ChunkDataCount dc;
 
-	QMap<ChunkType, Chunk *> c;
+	QMultiMap<ChunkType, Chunk *> c;
 
 	void subproc()
 	{
@@ -476,7 +476,7 @@ private:
 	{
 		f->seek( p + CHUNKHEADERSIZE + dl );
 
-		QMap<ChunkType, Chunk *> temp;
+		QMultiMap<ChunkType, Chunk *> temp;
 
 		while ( f->pos() < ( p + h.l ) ) {
 			ChunkPos q = f->pos();
@@ -487,16 +487,16 @@ private:
 
 			Chunk * z = new Chunk( f, k, q );
 
-			temp.insertMulti( k.t, z );
+			temp.insert( k.t, z );
 
 			f->seek( q + k.l );
 		}
 
-		QMapIterator<ChunkType, Chunk *> tempIter( temp );
+		QMultiMapIterator<ChunkType, Chunk *> tempIter( temp );
 
 		while ( tempIter.hasNext() ) {
 			tempIter.next();
-			c.insertMulti( tempIter.key(), tempIter.value() );
+			c.insert( tempIter.key(), tempIter.value() );
 		}
 
 		f->seek( p + h.l );

--- a/src/lib/importex/col.cpp
+++ b/src/lib/importex/col.cpp
@@ -530,7 +530,7 @@ QDomElement textureElement( const NifModel * nif, QDomElement effect, QModelInde
 
 	if ( iTexture.isValid() ) {
 		// we have texture
-		QFileInfo textureFile = nif->get<QString>( iTexture, "File Name" );
+		QFileInfo textureFile = QFileInfo(nif->get<QString>( iTexture, "File Name" ));
 
 		// surface
 		QDomElement newparam = doc.createElement( "newparam" );
@@ -770,7 +770,7 @@ void attachNiShape ( const NifModel * nif, QDomElement parentNode, int idx )
 			QModelIndex iUV = nif->getIndex( iProp, "UV Sets" );
 
 			for ( int row = 0; row < uvCount; row++ ) {
-				QVector<Vector2> uvMap = nif->getArray<Vector2>( iUV.child( row, 0 ) );
+				QVector<Vector2> uvMap = nif->getArray<Vector2>( nif->index( row, 0, iUV ) );
 				mesh.appendChild( uvMapElement( uvMap, idx, row ) );
 
 				if ( uvMap.size() > 0 )
@@ -845,7 +845,7 @@ void attachNiShape ( const NifModel * nif, QDomElement parentNode, int idx )
 				QVector<QVector<quint16> > strips;
 
 				for ( int r = 0; r < nif->rowCount( iPoints ); r++ )
-					strips.append( nif->getArray<quint16>( iPoints.child( r, 0 ) ) );
+					strips.append( nif->getArray<quint16>( nif->index( r, 0, iPoints ) ) );
 
 				tri = triangulate( strips );
 			} else {

--- a/src/model/basemodel.cpp
+++ b/src/model/basemodel.cpp
@@ -490,7 +490,7 @@ QVariant BaseModel::data( const QModelIndex & index, int role ) const
 			}
 		}
 		return QVariant();
-	case Qt::BackgroundColorRole:
+	case Qt::BackgroundRole:
 		{
 			if ( column == ValueCol && item->value().isColor() ) {
 				return item->value().toColor();

--- a/src/model/nifdelegate.cpp
+++ b/src/model/nifdelegate.cpp
@@ -165,7 +165,7 @@ public:
 
 		// Color the field background if the value type is a color
 		//	Otherwise normal behavior
-		QVariant color = index.data( Qt::BackgroundColorRole );
+		QVariant color = index.data( Qt::BackgroundRole );
 		if ( color.canConvert<QColor>() )
 			painter->fillRect( option.rect, color.value<QColor>() );
 		else if ( option.state & QStyle::State_Selected )
@@ -195,7 +195,7 @@ public:
 		// Increase height by 25%
 		height *= 1.25;
 
-		return {option.fontMetrics.width( text ), height};
+		return {option.fontMetrics.horizontalAdvance( text ), (int)height};
 	}
 
 	QWidget * createEditor( QWidget * parent, const QStyleOptionViewItem &, const QModelIndex & index ) const override final

--- a/src/model/nifmodel.cpp
+++ b/src/model/nifmodel.cpp
@@ -414,7 +414,7 @@ void NifModel::updateHeader()
 
 			if ( nstrings > 0 && iArray.isValid() ) {
 				for ( int row = 0; row < nstrings; ++row ) {
-					int len = get<QString>( iArray.child( row, 0 ) ).length();
+					int len = get<QString>( this->index( row, 0, iArray ) ).length();
 
 					if ( len > maxlen )
 						maxlen = len;
@@ -1484,7 +1484,7 @@ QVariant NifModel::data( const QModelIndex & idx, int role ) const
 			}
 		}
 		return QVariant();
-	case Qt::BackgroundColorRole:
+	case Qt::BackgroundRole:
 		{
 			// "notify" about an invalid index in "Triangles"
 			// TODO: checkbox, "show invalid only"
@@ -2906,7 +2906,7 @@ bool NifModel::assignString( NifItem * item, const QString & string, bool replac
 
 		// Simply replace the string
 		if ( replace && idx >= 0 && idx < nstrings ) {
-			return BaseModel::set<QString>( iArray.child( idx, 0 ), string );
+			return BaseModel::set<QString>( this->index( idx, 0, iArray ), string );
 		}
 
 		QVector<QString> stringVector = getArray<QString>( iArray );
@@ -2921,7 +2921,7 @@ bool NifModel::assignString( NifItem * item, const QString & string, bool replac
 		// Append string to end of list
 		set<uint>( header, "Num Strings", nstrings + 1 );
 		updateArray( header, "Strings" );
-		BaseModel::set<QString>( iArray.child( nstrings, 0 ), string );
+		BaseModel::set<QString>( this->index( nstrings, 0, iArray ), string );
 
 		v.changeType( NifValue::tStringIndex );
 		return set<int>( pItem, nstrings );

--- a/src/model/nifproxymodel.cpp
+++ b/src/model/nifproxymodel.cpp
@@ -485,7 +485,7 @@ QList<QModelIndex> NifProxyModel::mapFrom( const QModelIndex & idx ) const
 Qt::ItemFlags NifProxyModel::flags( const QModelIndex & index ) const
 {
 	if ( !nif )
-		return 0;
+		return Qt::NoItemFlags;
 
 	return nif->flags( mapTo( index ) );
 }

--- a/src/nifskope.h
+++ b/src/nifskope.h
@@ -78,7 +78,7 @@ class QActionGroup;
 class QComboBox;
 class QGraphicsScene;
 class QProgressBar;
-class QStringList;
+//class QStringList;
 class QTimer;
 class QTreeView;
 class QUdpSocket;

--- a/src/spells/animation.cpp
+++ b/src/spells/animation.cpp
@@ -87,13 +87,13 @@ public:
 					QModelIndex iCtrlBlcks = kf.getIndex( iSeq, "Controlled Blocks" );
 
 					for ( int r = 0; r < kf.rowCount( iCtrlBlcks ); r++ ) {
-						QString nodeName = kf.string( iCtrlBlcks.child( r, 0 ), "Node Name", false );
+						QString nodeName = kf.string( nif->index( r, 0, iCtrlBlcks ), "Node Name", false );
 
 						if ( nodeName.isEmpty() )
-							nodeName = kf.string( iCtrlBlcks.child( r, 0 ), "Target Name", false ); // 10.0.1.0
+							nodeName = kf.string( nif->index( r, 0, iCtrlBlcks ), "Target Name", false ); // 10.0.1.0
 
 						if ( nodeName.isEmpty() ) {
-							QModelIndex iNodeName = kf.getIndex( iCtrlBlcks.child( r, 0 ), "Node Name Offset" );
+							QModelIndex iNodeName = kf.getIndex( nif->index( r, 0, iCtrlBlcks ), "Node Name Offset" );
 							nodeName = iNodeName.sibling( iNodeName.row(), NifModel::ValueCol ).data( NifSkopeDisplayRole ).toString();
 						}
 
@@ -140,14 +140,14 @@ public:
 					int numSeq  = nif->get<int>( iCtrlManager, "Num Controller Sequences" );
 					nif->set<int>( iCtrlManager, "Num Controller Sequences", numSeq + 1 );
 					nif->updateArray( iCtrlManager, "Controller Sequences" );
-					nif->setLink( nif->getIndex( iCtrlManager, "Controller Sequences" ).child( numSeq, 0 ), nSeq );
+					nif->setLink( nif->index( numSeq, 0, nif->getIndex( iCtrlManager, "Controller Sequences" ) ), nSeq );
 					QModelIndex iSeq = nif->getBlock( nSeq, "NiControllerSequence" );
 					nif->setLink( iSeq, "Manager", nif->getBlockNumber( iCtrlManager ) );
 
 					QModelIndex iCtrlBlcks = nif->getIndex( iSeq, "Controlled Blocks" );
 
 					for ( int r = 0; r < nif->rowCount( iCtrlBlcks ); r++ ) {
-						QModelIndex iCtrlBlck = iCtrlBlcks.child( r, 0 );
+						QModelIndex iCtrlBlck = nif->index( r, 0, iCtrlBlcks );
 
 						if ( nif->getLink( iCtrlBlck, "Controller" ) == -1 )
 							nif->setLink( iCtrlBlck, "Controller", iMultiTransformerIdx );
@@ -274,7 +274,7 @@ public:
 			int r;
 
 			for ( r = 0; r < nif->rowCount( iArray ); r++ ) {
-				if ( nif->get<QString>( iArray.child( r, 0 ), "Name" ) == name )
+				if ( nif->get<QString>( nif->index( r, 0, iArray ), "Name" ) == name )
 					break;
 			}
 
@@ -286,8 +286,8 @@ public:
 		nif->set<int>( iNum, r + blocksToAdd.count() );
 		nif->updateArray( iArray );
 		for ( const QPersistentModelIndex& idx : blocksToAdd ) {
-			nif->set<QString>( iArray.child( r, 0 ), "Name", nif->get<QString>( idx, "Name" ) );
-			nif->setLink( iArray.child( r, 0 ), "AV Object", nif->getBlockNumber( idx ) );
+			nif->set<QString>( nif->index( r, 0, iArray ), "Name", nif->get<QString>( idx, "Name" ) );
+			nif->setLink( nif->index( r, 0, iArray ), "AV Object", nif->getBlockNumber( idx ) );
 			r++;
 		}
 	}
@@ -327,7 +327,7 @@ public:
 
 	    for( int i = 0; i < 3; i++ )
 	    {
-	        QModelIndex iRot = iRots.child( i, 0 );
+	        QModelIndex iRot = nif->index( i, 0, iRots );
 	        nif->set<int>( iRot, "Num Keys", nif->get<int>(index, "Num Rotation Keys") );
 	        nif->set<int>( iRot, "Interpolation", rotationType );
 	        nif->updateArray( iRot, "Keys" );
@@ -335,7 +335,7 @@ public:
 
 	    for ( int q = 0; q < nif->rowCount( iQuats ); q++ )
 	    {
-	        QModelIndex iQuat = iQuats.child( q, 0 );
+	        QModelIndex iQuat = nif->index( q, 0, iQuats );
 
 	        float time = nif->get<float>( iQuat, "Time" );
 	        Quat value = nif->get<Quat>( iQuat, "Value" );
@@ -346,9 +346,9 @@ public:
 	        float x, y, z;
 	        tlocal.toEuler( x, y, z );
 
-	        QModelIndex xRot = iRots.child( 0, 0 );
-	        QModelIndex yRot = iRots.child( 1, 0 );
-	        QModelIndex zRot = iRots.child( 2, 0 );
+	        QModelIndex xRot = nif->index( 0, 0, iRots );
+	        QModelIndex yRot = nif->index( 1, 0, iRots );
+	        QModelIndex zRot = nif->index( 2, 0, iRots );
 
 	        xRot = nif->getIndex( xRot, "Keys" );
 
@@ -388,7 +388,7 @@ public:
 		auto objs = nif->getIndex( index, "Objs" );
 		auto numObjs = nif->rowCount( objs );
 		for ( int i = 0; i < numObjs; i++ ) {
-			auto c = objs.child( i, 0 );
+			auto c = nif->index( i, 0, objs );
 			auto iAV = nif->getIndex( c, "AV Object" );
 
 

--- a/src/spells/blocks.cpp
+++ b/src/spells/blocks.cpp
@@ -198,10 +198,10 @@ QStringList getStringsArray( NifModel * nif, const QModelIndex & parent,
 
 	if ( name.isEmpty() ) {
 		for ( int i = 0; i < nif->rowCount( iArr ); i++ )
-			strings << nif->string( iArr.child( i, 0 ) );
+			strings << nif->string( nif->index( i, 0, iArr ) );
 	} else {
 		for ( int i = 0; i < nif->rowCount( iArr ); i++ )
-			strings << nif->string( iArr.child( i, 0 ), name, false );
+			strings << nif->string( nif->index( i, 0, iArr ), name, false );
 	}
 
 	return strings;
@@ -216,10 +216,10 @@ void setStringsArray( NifModel * nif, const QModelIndex & parent, QStringList & 
 
 	if ( name.isEmpty() ) {
 		for ( int i = 0; i < nif->rowCount( iArr ); i++ )
-			nif->set<QString>( iArr.child( i, 0 ), strings.takeFirst() );
+			nif->set<QString>( nif->index( i, 0, iArr ), strings.takeFirst() );
 	} else {
 		for ( int i = 0; i < nif->rowCount( iArr ); i++ )
-			nif->set<QString>( iArr.child( i, 0 ), name, strings.takeFirst() );
+			nif->set<QString>( nif->index( i, 0, iArr ), name, strings.takeFirst() );
 	}
 }
 //! Get "Name" et al. for NiObjectNET, NiExtraData, NiPSysModifier, etc.
@@ -227,7 +227,7 @@ QStringList getNiObjectRootStrings( NifModel * nif, const QModelIndex & iBlock )
 {
 	QStringList strings;
 	for ( int i = 0; i < nif->rowCount( iBlock ); i++ ) {
-		auto iString = iBlock.child( i, 0 );
+		auto iString = nif->index( i, 0, iBlock );
 		if ( rootStringList.contains( nif->itemName( iString ) ) )
 			strings << nif->string( iString );
 	}
@@ -238,7 +238,7 @@ QStringList getNiObjectRootStrings( NifModel * nif, const QModelIndex & iBlock )
 void setNiObjectRootStrings( NifModel * nif, const QModelIndex & iBlock, QStringList & strings )
 {
 	for ( int i = 0; i < nif->rowCount( iBlock ); i++ ) {
-		auto iString = iBlock.child( i, 0 );
+		auto iString = nif->index( i, 0, iBlock );
 		if ( rootStringList.contains( nif->itemName( iString ) ) )
 			nif->set<QString>( iString, strings.takeFirst() );
 	}
@@ -253,7 +253,7 @@ QStringList getStringsNiMesh( NifModel * nif, const QModelIndex & iBlock )
 		return {};
 
 	for ( int i = 0; i < nif->rowCount( iData ); i++ )
-		strings << getStringsArray( nif, iData.child( i, 0 ), "Component Semantics", "Name" );
+		strings << getStringsArray( nif, nif->index( i, 0, iData ), "Component Semantics", "Name" );
 
 	return strings;
 }
@@ -265,7 +265,7 @@ void setStringsNiMesh( NifModel * nif, const QModelIndex & iBlock, QStringList &
 		return;
 
 	for ( int i = 0; i < nif->rowCount( iData ); i++ )
-		setStringsArray( nif, iData.child( i, 0 ), strings, "Component Semantics", "Name" );
+		setStringsArray( nif, nif->index( i, 0, iData ), strings, "Component Semantics", "Name" );
 }
 //! Get strings for NiSequence
 QStringList getStringsNiSequence( NifModel * nif, const QModelIndex & iBlock )
@@ -276,7 +276,7 @@ QStringList getStringsNiSequence( NifModel * nif, const QModelIndex & iBlock )
 		return {};
 
 	for ( int i = 0; i < nif->rowCount( iControlledBlocks ); i++ ) {
-		auto iChild = iControlledBlocks.child( i, 0 );
+		auto iChild = nif->index( i, 0, iControlledBlocks );
 		strings << nif->string( iChild, "Target Name", false )
 				<< nif->string( iChild, "Node Name", false )
 				<< nif->string( iChild, "Property Type", false )
@@ -295,7 +295,7 @@ void setStringsNiSequence( NifModel * nif, const QModelIndex & iBlock, QStringLi
 		return;
 
 	for ( int i = 0; i < nif->rowCount( iControlledBlocks ); i++ ) {
-		auto iChild = iControlledBlocks.child( i, 0 );
+		auto iChild = nif->index( i, 0, iControlledBlocks );
 		nif->set<QString>( iChild, "Target Name", strings.takeFirst() );
 		nif->set<QString>( iChild, "Node Name", strings.takeFirst() );
 		nif->set<QString>( iChild, "Property Type", strings.takeFirst() );
@@ -363,7 +363,7 @@ bool addLink( NifModel * nif, const QModelIndex & iParent, const QString & array
 			int numlinks = nif->get<int>( iSize );
 			nif->set<int>( iSize, numlinks + 1 );
 			nif->updateArray( iArray );
-			nif->setLink( iArray.child( numlinks, 0 ), link );
+			nif->setLink( nif->index( numlinks, 0, iArray ), link );
 			return true;
 		}
 
@@ -374,7 +374,7 @@ bool addLink( NifModel * nif, const QModelIndex & iParent, const QString & array
 		if ( nif->isArray( iArray ) && item ) {
 			for ( int c = 0; c < item->childCount(); c++ ) {
 				if ( item->child( c )->value().toLink() == -1 ) {
-					nif->setLink( iArray.child( c, 0 ), link );
+					nif->setLink( nif->index( c, 0, iArray ), link );
 					return true;
 				}
 			}
@@ -673,7 +673,8 @@ public:
 	{
 		QMenu menu;
 		menu.addSection( tr( "Alphabetical" ) );
-		for ( QMenu * m : blockMenu( nif, NifModel::allNiBlocks().toStdList(), true, true ) ) {
+		auto list = NifModel::allNiBlocks();
+		for ( QMenu * m : blockMenu( nif, std::list(list.begin(), list.end()), true, true ) ) {
 			if ( m->title().isEmpty() )
 				menu.addSection( tr( "Categories" ) );
 			else if ( m->actions().size() == 1 )
@@ -827,7 +828,8 @@ public:
 		NifItem * item = static_cast<NifItem *>(index.internalPointer());
 		auto type = item->temp();
 
-		std::list<QString> allIds = nif->allNiBlocks().toStdList();
+		auto list = nif->allNiBlocks();
+		std::list<QString> allIds = std::list(list.begin(), list.end());
 		blockFilter( nif, allIds, type );
 
 		auto iBlock = nif->getBlock( index );
@@ -1047,7 +1049,7 @@ class spCopyBlock final : public Spell
 public:
 	QString name() const override final { return Spell::tr( "Copy" ); }
 	QString page() const override final { return Spell::tr( "Block" ); }
-	QKeySequence hotkey() const override final { return{ Qt::CTRL + Qt::SHIFT + Qt::Key_C }; }
+	QKeySequence hotkey() const override final { return{ Qt::CTRL, Qt::SHIFT, Qt::Key_C }; }
 
 	bool isApplicable( const NifModel * nif, const QModelIndex & index ) override final
 	{
@@ -1181,7 +1183,7 @@ class spPasteOverBlock final : public Spell
 public:
 	QString name() const override final { return Spell::tr( "Paste Over" ); }
 	QString page() const override final { return Spell::tr( "Block" ); }
-	QKeySequence hotkey() const override final { return{ Qt::CTRL + Qt::SHIFT + Qt::Key_V }; }
+	QKeySequence hotkey() const override final { return{ Qt::CTRL, Qt::SHIFT, Qt::Key_V }; }
 
 	QPair<QString, QString> acceptFormat( const QString & format, const NifModel * nif, const QModelIndex & iBlock )
 	{
@@ -1824,7 +1826,7 @@ class spDuplicateBlock final : public Spell
 public:
 	QString name() const override final { return Spell::tr( "Duplicate" ); }
 	QString page() const override final { return Spell::tr( "Block" ); }
-	QKeySequence hotkey() const override final { return{ Qt::CTRL + Qt::SHIFT + Qt::Key_D }; }
+	QKeySequence hotkey() const override final { return{ Qt::CTRL, Qt::SHIFT, Qt::Key_D }; }
 
 	bool isApplicable( const NifModel * nif, const QModelIndex & index ) override final
 	{
@@ -2018,7 +2020,7 @@ public:
 				QList<QPair<QString, qint32> > links;
 
 				for ( int r = 0; r < nif->rowCount( iChildren ); r++ ) {
-					qint32 l = nif->getLink( iChildren.child( r, 0 ) );
+					qint32 l = nif->getLink( nif->index( r, 0, iChildren ) );
 
 					if ( l >= 0 )
 						links.append( QPair<QString, qint32>( nif->get<QString>( nif->getBlock( l ), "Name" ), l ) );
@@ -2027,8 +2029,8 @@ public:
 				std::stable_sort( links.begin(), links.end() );
 
 				for ( int r = 0; r < links.count(); r++ ) {
-					if ( links[r].second != nif->getLink( iChildren.child( r, 0 ) ) )
-						nif->setLink( iChildren.child( r, 0 ), links[r].second );
+					if ( links[r].second != nif->getLink( nif->index( r, 0, iChildren ) ) )
+						nif->setLink( nif->index( r, 0, iChildren ), links[r].second );
 
 					nif->set<int>( iNumChildren, links.count() );
 					nif->updateArray( iChildren );
@@ -2093,7 +2095,7 @@ public:
 		int attachedNodeNumber = thisBlockNumber++;
 
 		// replace this block with the attached node
-		nif->setLink( nif->getIndex( iParent, "Children" ).child( thisBlockIndex, 0 ), attachedNodeNumber );
+		nif->setLink( nif->index( thisBlockIndex, 0, nif->getIndex( iParent, "Children" ) ), attachedNodeNumber );
 
 		// attach ourselves to the attached node
 		addLink( nif, attachedNode, "Children", thisBlockNumber );

--- a/src/spells/color.cpp
+++ b/src/spells/color.cpp
@@ -54,12 +54,12 @@ public:
 
 	bool isApplicable( const NifModel * nif, const QModelIndex & index ) override final
 	{
-		return nif->isArray( index ) && nif->getValue( index.child( 0, 0 ) ).isColor();
+		return nif->isArray( index ) && nif->getValue( nif->index( 0, 0, index ) ).isColor();
 	}
 
 	QModelIndex cast( NifModel * nif, const QModelIndex & index ) override final
 	{
-		QModelIndex colorIdx = (nif->isArray( index )) ? index.child( 0, 0 ) : index;
+		QModelIndex colorIdx = (nif->isArray( index )) ? nif->index( 0, 0, index ) : index;
 
 		auto typ = nif->getValue( colorIdx ).type();
 		if ( typ == NifValue::tColor3 )

--- a/src/spells/havok.cpp
+++ b/src/spells/havok.cpp
@@ -166,8 +166,8 @@ public:
 		nif->set<float>( iCVS, "Radius", spnRadius->value() );
 
 		// for arrow detection: [0, 0, -0, 0, 0, -0]
-		nif->set<float>( nif->getIndex( iCVS, "Unknown 6 Floats" ).child( 2, 0 ), -0.0 );
-		nif->set<float>( nif->getIndex( iCVS, "Unknown 6 Floats" ).child( 5, 0 ), -0.0 );
+		nif->set<float>( nif->index( 2, 0, nif->getIndex( iCVS, "Unknown 6 Floats" ) ), -0.0 );
+		nif->set<float>( nif->index( 5, 0, nif->getIndex( iCVS, "Unknown 6 Floats" ) ), -0.0 );
 
 		QModelIndex iParent = nif->getBlock( nif->getParent( nif->getBlockNumber( index ) ) );
 		QModelIndex collisionLink = nif->getIndex( iParent, "Collision Object" );
@@ -246,8 +246,8 @@ public:
 			}
 		}
 
-		QModelIndex iBodyA = nif->getBlock( nif->getLink( nif->getIndex( iConstraint, "Entities" ).child( 0, 0 ) ), "bhkRigidBody" );
-		QModelIndex iBodyB = nif->getBlock( nif->getLink( nif->getIndex( iConstraint, "Entities" ).child( 1, 0 ) ), "bhkRigidBody" );
+		QModelIndex iBodyA = nif->getBlock( nif->getLink( nif->index( 0, 0, nif->getIndex( iConstraint, "Entities" ) ) ), "bhkRigidBody" );
+		QModelIndex iBodyB = nif->getBlock( nif->getLink( nif->index( 1, 0, nif->getIndex( iConstraint, "Entities" ) ) ), "bhkRigidBody" );
 
 		if ( !iBodyA.isValid() || !iBodyB.isValid() ) {
 			Message::warning( nullptr, Spell::tr( "Couldn't find the bodies for this constraint." ) );
@@ -361,8 +361,8 @@ public:
 		if ( !iSpring.isValid() )
 			iSpring = iConstraint;
 
-		QModelIndex iBodyA = nif->getBlock( nif->getLink( nif->getIndex( iConstraint, "Entities" ).child( 0, 0 ) ), "bhkRigidBody" );
-		QModelIndex iBodyB = nif->getBlock( nif->getLink( nif->getIndex( iConstraint, "Entities" ).child( 1, 0 ) ), "bhkRigidBody" );
+		QModelIndex iBodyA = nif->getBlock( nif->getLink( nif->index( 0, 0, nif->getIndex( iConstraint, "Entities" ) ) ), "bhkRigidBody" );
+		QModelIndex iBodyB = nif->getBlock( nif->getLink( nif->index( 1, 0, nif->getIndex( iConstraint, "Entities" ) ) ), "bhkRigidBody" );
 
 		if ( !iBodyA.isValid() || !iBodyB.isValid() ) {
 			Message::warning( nullptr, Spell::tr( "Couldn't find the bodies for this constraint" ) );
@@ -416,7 +416,7 @@ public:
 				QModelIndex iPoints = nif->getIndex( iData, "Points" );
 
 				for ( int x = 0; x < nif->rowCount( iPoints ); x++ ) {
-					tris += triangulate( nif->getArray<quint16>( iPoints.child( x, 0 ) ) );
+					tris += triangulate( nif->getArray<quint16>( nif->index( x, 0, iPoints ) ) );
 				}
 
 				QMutableVectorIterator<Triangle> it( tris );
@@ -453,9 +453,9 @@ public:
 		nif->set<int>( iPackedShape, "Num Sub Shapes", 1 );
 		QModelIndex iSubShapes = nif->getIndex( iPackedShape, "Sub Shapes" );
 		nif->updateArray( iSubShapes );
-		nif->set<int>( iSubShapes.child( 0, 0 ), "Layer", 1 );
-		nif->set<int>( iSubShapes.child( 0, 0 ), "Num Vertices", vertices.count() );
-		nif->set<int>( iSubShapes.child( 0, 0 ), "Material", nif->get<int>( iShape, "Material" ) );
+		nif->set<int>( nif->index( 0, 0, iSubShapes ), "Layer", 1 );
+		nif->set<int>( nif->index( 0, 0, iSubShapes ), "Num Vertices", vertices.count() );
+		nif->set<int>( nif->index( 0, 0, iSubShapes ), "Material", nif->get<int>( iShape, "Material" ) );
 		nif->setArray<float>( iPackedShape, "Unknown Floats", { 0.0f, 0.0f, 0.1f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, 0.1f } );
 		nif->set<float>( iPackedShape, "Scale", 1.0f );
 		nif->setArray<float>( iPackedShape, "Unknown Floats 2", { 1.0f, 1.0f, 1.0f } );
@@ -468,8 +468,8 @@ public:
 		nif->updateArray( iTriangles );
 
 		for ( int t = 0; t < triangles.size(); t++ ) {
-			nif->set<Triangle>( iTriangles.child( t, 0 ), "Triangle", triangles[ t ] );
-			nif->set<Vector3>( iTriangles.child( t, 0 ), "Normal", normals.value( t ) );
+			nif->set<Triangle>( nif->index( t, 0, iTriangles ), "Triangle", triangles[ t ] );
+			nif->set<Vector3>( nif->index( t, 0, iTriangles ), "Normal", normals.value( t ) );
 		}
 
 		nif->set<int>( iPackedData, "Num Vertices", vertices.count() );

--- a/src/spells/mesh.cpp
+++ b/src/spells/mesh.cpp
@@ -77,7 +77,7 @@ static void removeWasteVertices( NifModel * nif, const QModelIndex & iData, cons
 		QModelIndex iUVSets = nif->getIndex( iData, "UV Sets" );
 
 		for ( int r = 0; r < nif->rowCount( iUVSets ); r++ ) {
-			texco << nif->getArray<Vector2>( iUVSets.child( r, 0 ) );
+			texco << nif->getArray<Vector2>( nif->index( r, 0, iUVSets ) );
 
 			if ( texco.last().count() != verts.count() )
 				throw QString( Spell::tr( "UV array size differs" ) );
@@ -107,7 +107,7 @@ static void removeWasteVertices( NifModel * nif, const QModelIndex & iData, cons
 		QModelIndex iPoints = nif->getIndex( iData, "Points" );
 
 		for ( int r = 0; r < nif->rowCount( iPoints ); r++ ) {
-			strips << nif->getArray<quint16>( iPoints.child( r, 0 ) );
+			strips << nif->getArray<quint16>( nif->index( r, 0, iPoints ) );
 			for ( const auto p : strips.last() ) {
 				used.insert( p, true );
 			}
@@ -165,7 +165,7 @@ static void removeWasteVertices( NifModel * nif, const QModelIndex & iData, cons
 		nif->setArray<Triangle>( iData, "Triangles", tris );
 
 		for ( int r = 0; r < nif->rowCount( iPoints ); r++ )
-			nif->setArray<quint16>( iPoints.child( r, 0 ), strips[r] );
+			nif->setArray<quint16>( nif->index( r, 0, iPoints ), strips[r] );
 
 		nif->set<int>( iData, "Num Vertices", verts.count() );
 		nif->updateArray( iData, "Vertices" );
@@ -176,8 +176,8 @@ static void removeWasteVertices( NifModel * nif, const QModelIndex & iData, cons
 		nif->setArray<Color4>( iData, "Vertex Colors", colors );
 
 		for ( int r = 0; r < nif->rowCount( iUVSets ); r++ ) {
-			nif->updateArray( iUVSets.child( r, 0 ) );
-			nif->setArray<Vector2>( iUVSets.child( r, 0 ), texco[r] );
+			nif->updateArray( nif->index( r, 0, iUVSets ) );
+			nif->setArray<Vector2>( nif->index( r, 0, iUVSets ), texco[r] );
 		}
 
 		// process NiSkinData
@@ -189,10 +189,10 @@ static void removeWasteVertices( NifModel * nif, const QModelIndex & iData, cons
 
 		for ( int b = 0; b < nif->rowCount( iBones ); b++ ) {
 			QVector<QPair<int, float> > weights;
-			QModelIndex iWeights = nif->getIndex( iBones.child( b, 0 ), "Vertex Weights" );
+			QModelIndex iWeights = nif->getIndex( nif->index( b, 0, iBones ), "Vertex Weights" );
 
 			for ( int w = 0; w < nif->rowCount( iWeights ); w++ ) {
-				weights.append( QPair<int, float>( nif->get<int>( iWeights.child( w, 0 ), "Index" ), nif->get<float>( iWeights.child( w, 0 ), "Weight" ) ) );
+				weights.append( QPair<int, float>( nif->get<int>( nif->index( w, 0, iWeights ), "Index" ), nif->get<float>( nif->index( w, 0, iWeights ), "Weight" ) ) );
 			}
 
 			for ( int x = weights.count() - 1; x >= 0; x-- ) {
@@ -209,12 +209,12 @@ static void removeWasteVertices( NifModel * nif, const QModelIndex & iData, cons
 					w.first = map[ w.first ];
 			}
 
-			nif->set<int>( iBones.child( b, 0 ), "Num Vertices", weights.count() );
+			nif->set<int>( nif->index( b, 0, iBones ), "Num Vertices", weights.count() );
 			nif->updateArray( iWeights );
 
 			for ( int w = 0; w < weights.count(); w++ ) {
-				nif->set<int>( iWeights.child( w, 0 ), "Index", weights[w].first );
-				nif->set<float>( iWeights.child( w, 0 ), "Weight", weights[w].second );
+				nif->set<int>( nif->index( w, 0, iWeights ), "Index", weights[w].first );
+				nif->set<float>( nif->index( w, 0, iWeights ), "Weight", weights[w].second );
 			}
 		}
 
@@ -279,7 +279,7 @@ public:
 	void flip( NifModel * nif, const QModelIndex & index, int f )
 	{
 		if ( nif->isArray( index ) ) {
-			QModelIndex idx = index.child( 0, 0 );
+			QModelIndex idx = nif->index( 0, 0, index );
 
 			if ( idx.isValid() ) {
 				if ( nif->isArray( idx ) )
@@ -332,7 +332,7 @@ public:
 	bool isApplicable( const NifModel * nif, const QModelIndex & index ) override final
 	{
 		return ( nif->getValue( index ).type() == NifValue::tTriangle )
-		       || ( nif->isArray( index ) && nif->getValue( index.child( 0, 0 ) ).type() == NifValue::tTriangle );
+		       || ( nif->isArray( index ) && nif->getValue( nif->index( 0, 0, index ) ).type() == NifValue::tTriangle );
 	}
 
 	QModelIndex cast( NifModel * nif, const QModelIndex & index ) override final
@@ -487,7 +487,7 @@ public:
 			QModelIndex iUVSets = nif->getIndex( iData, "UV Sets" );
 
 			for ( int r = 0; r < nif->rowCount( iUVSets ); r++ ) {
-				texco << nif->getArray<Vector2>( iUVSets.child( r, 0 ) );
+				texco << nif->getArray<Vector2>( nif->index( r, 0, iUVSets ) );
 
 				if ( texco.last().count() != verts.count() )
 					throw QString( Spell::tr( "UV array size differs" ) );
@@ -555,7 +555,7 @@ public:
 			QModelIndex iPoints = nif->getIndex( iData, "Points" );
 
 			for ( int r = 0; r < nif->rowCount( iPoints ); r++ ) {
-				QVector<quint16> strip = nif->getArray<quint16>( iPoints.child( r, 0 ) );
+				QVector<quint16> strip = nif->getArray<quint16>( nif->index( r, 0, iPoints ) );
 				QMutableVectorIterator<quint16> istrp( strip );
 
 				while ( istrp.hasNext() ) {
@@ -565,7 +565,7 @@ public:
 						p = map.value( p );
 				}
 
-				nif->setArray<quint16>( iPoints.child( r, 0 ), strip );
+				nif->setArray<quint16>( nif->index( r, 0, iPoints ), strip );
 			}
 
 			// finally, remove the now unused vertices
@@ -697,7 +697,7 @@ public:
 		// Retrieve the verts
 		QVector<Vector3> verts;
 		for ( int i = 0; i < nif->rowCount( vertData ); i++ ) {
-			verts << nif->get<Vector3>( vertData.child( i, 0 ), "Vertex" );
+			verts << nif->get<Vector3>( nif->index( i, 0, vertData ), "Vertex" );
 		}
 
 		if ( verts.isEmpty() )
@@ -776,7 +776,7 @@ QModelIndex spUpdateTrianglesFromSkin::cast( NifModel * nif, const QModelIndex &
 	QVector<Triangle> tris;
 	auto iParts = nif->getIndex( iSkinPart, "Skin Partition Blocks" );
 	for ( int i = 0; i < nif->rowCount( iParts ) && iParts.isValid(); i++ )
-		tris << SkinPartition( nif, iParts.child( i, 0 ) ).getRemappedTriangles();
+		tris << SkinPartition( nif, nif->index( i, 0, iParts ) ).getRemappedTriangles();
 
 	nif->set<bool>( iData, "Has Triangles", true );
 	nif->set<ushort>( iData, "Num Triangles", tris.size() );

--- a/src/spells/misc.cpp
+++ b/src/spells/misc.cpp
@@ -221,7 +221,7 @@ public:
 		if ( item->isArray() && item->isBinary() ) {
 			parent = item;
 			iParent = index;
-			idx = index.child( 0, 0 );
+			idx = nif->index( 0, 0, index );
 		}
 
 		QString filename = QFileDialog::getOpenFileName( qApp->activeWindow(), tr( "Import Binary File" ), "", "*.*" );
@@ -275,7 +275,7 @@ QModelIndex spCollapseArray::numCollapser( NifModel * nif, QModelIndex & iNumEle
 		QVector<qint32> links;
 
 		for ( int r = 0; r < nif->rowCount( iArray ); r++ ) {
-			qint32 l = nif->getLink( iArray.child( r, 0 ) );
+			qint32 l = nif->getLink( nif->index( r, 0, iArray ) );
 
 			if ( l >= 0 )
 				links.append( l );

--- a/src/spells/morphctrl.cpp
+++ b/src/spells/morphctrl.cpp
@@ -50,23 +50,23 @@ public:
 				qCWarning( nsSpell ) << Spell::tr( "overriding base key frame, all other frames will be cleared" );
 				nif->set<int>( iMorphData, "Num Vertices", nif->get<int>( iMeshData, "Num Vertices" ) );
 				QVector<Vector3> verts = nif->getArray<Vector3>( iMeshData, "Vertices" );
-				nif->updateArray( iFrames.child( 0, 0 ), "Vectors" );
-				nif->setArray( iFrames.child( 0, 0 ), "Vectors", verts );
+				nif->updateArray( nif->index( 0, 0, iFrames ), "Vectors" );
+				nif->setArray( nif->index( 0, 0, iFrames ), "Vectors", verts );
 				verts.fill( Vector3() );
 
 				for ( int f = 1; f < nif->rowCount( iFrames ); f++ ) {
-					nif->updateArray( iFrames.child( f, 0 ), "Vectors" );
-					nif->setArray<Vector3>( iFrames.child( f, 0 ), "Vectors", verts );
+					nif->updateArray( nif->index( f, 0, iFrames ), "Vectors" );
+					nif->setArray<Vector3>( nif->index( f, 0, iFrames ), "Vectors", verts );
 				}
 			} else {
 				QVector<Vector3> verts = nif->getArray<Vector3>( iMeshData, "Vertices" );
-				QVector<Vector3> base  = nif->getArray<Vector3>( iFrames.child( 0, 0 ), "Vectors" );
+				QVector<Vector3> base  = nif->getArray<Vector3>( nif->index( 0, 0, iFrames ), "Vectors" );
 				QVector<Vector3> frame( base.count(), Vector3() );
 
 				for ( int n = 0; n < base.count(); n++ )
 					frame[ n ] = verts.value( n ) - base[ n ];
 
-				nif->setArray<Vector3>( iFrames.child( selFrame, 0 ), "Vectors", frame );
+				nif->setArray<Vector3>( nif->index( selFrame, 0, iFrames ), "Vectors", frame );
 			}
 		}
 
@@ -111,7 +111,7 @@ public:
 			QStringList list;
 
 			for ( int i = 0; i < nif->rowCount( iFrames ); i++ ) {
-				list << nif->get<QString>( iFrames.child( i, 0 ), "Frame Name" );
+				list << nif->get<QString>( nif->index( i, 0, iFrames ), "Frame Name" );
 			}
 
 			return list;

--- a/src/spells/normals.cpp
+++ b/src/spells/normals.cpp
@@ -85,7 +85,7 @@ public:
 				QVector<QVector<quint16> > strips;
 
 				for ( int r = 0; r < nif->rowCount( iPoints ); r++ )
-					strips.append( nif->getArray<quint16>( iPoints.child( r, 0 ) ) );
+					strips.append( nif->getArray<quint16>( nif->index( r, 0, iPoints ) ) );
 
 				triangles = triangulate( strips );
 			} else {
@@ -116,7 +116,7 @@ public:
 				auto numParts = nif->get<int>( iPart, "Num Skin Partition Blocks" );
 				auto iParts = nif->getIndex( iPart, "Partition" );
 				for ( int i = 0; i < numParts; i++ )
-					triangles << nif->getArray<Triangle>( iParts.child( i, 0 ), "Triangles" );
+					triangles << nif->getArray<Triangle>( nif->index( i, 0, iParts ), "Triangles" );
 			}
 
 			QVector<Vector3> verts;
@@ -317,7 +317,7 @@ public:
 	bool isApplicable( const NifModel * nif, const QModelIndex & index ) override final
 	{
 		return ( nif->getValue( index ).type() == NifValue::tVector3 )
-		       || ( nif->isArray( index ) && nif->getValue( index.child( 0, 0 ) ).type() == NifValue::tVector3 );
+		       || ( nif->isArray( index ) && nif->getValue( nif->index( 0, 0, index ) ).type() == NifValue::tVector3 );
 	}
 
 	QModelIndex cast( NifModel * nif, const QModelIndex & index ) override final

--- a/src/spells/optimize.cpp
+++ b/src/spells/optimize.cpp
@@ -447,8 +447,8 @@ public:
 		QModelIndex iUVb = nif->getIndex( iDataB, "UV Sets" );
 
 		for ( int r = 0; r < nif->rowCount( iUVa ); r++ ) {
-			nif->updateArray( iUVa.child( r, 0 ) );
-			nif->setArray<Vector2>( iUVa.child( r, 0 ), nif->getArray<Vector2>( iUVa.child( r, 0 ) ).mid( 0, numA ) + nif->getArray<Vector2>( iUVb.child( r, 0 ) ) );
+			nif->updateArray( nif->index( r, 0, iUVa ) );
+			nif->setArray<Vector2>( nif->index( r, 0, iUVa ), nif->getArray<Vector2>( nif->index( r, 0, iUVa ) ).mid( 0, numA ) + nif->getArray<Vector2>( nif->index( r, 0, iUVb ) ) );
 		}
 
 		int triCntA = nif->get<int>( iDataA, "Num Triangles" );
@@ -477,15 +477,15 @@ public:
 		nif->updateArray( iDataA, "Points" );
 
 		for ( int r = 0; r < stripCntB; r++ ) {
-			QVector<quint16> strip = nif->getArray<quint16>( nif->getIndex( iDataB, "Points" ).child( r, 0 ) );
+			QVector<quint16> strip = nif->getArray<quint16>( nif->index( r, 0, nif->getIndex( iDataB, "Points" ) ) );
 			QMutableVectorIterator<quint16> it( strip );
 
 			while ( it.hasNext() )
 				it.next() += numA;
 
-			nif->set<int>( nif->getIndex( iDataA, "Strip Lengths" ).child( r + stripCntA, 0 ), strip.size() );
-			nif->updateArray( nif->getIndex( iDataA, "Points" ).child( r + stripCntA, 0 ) );
-			nif->setArray<quint16>( nif->getIndex( iDataA, "Points" ).child( r + stripCntA, 0 ), strip );
+			nif->set<int>( nif->index( r + stripCntA, 0, nif->getIndex( iDataA, "Strip Lengths" ) ), strip.size() );
+			nif->updateArray( nif->index( r + stripCntA, 0, nif->getIndex( iDataA, "Points" ) ) );
+			nif->setArray<quint16>( nif->index( r + stripCntA, 0, nif->getIndex( iDataA, "Points" ) ), strip );
 		}
 
 		spUpdateCenterRadius CenterRadius;
@@ -499,7 +499,7 @@ REGISTER_SPELL( spCombiTris )
 void scan( const QModelIndex & idx, NifModel * nif, QMap<QString, qint32> & usedStrings, bool hasCED )
 {
 	for ( int i = 0; i < nif->rowCount( idx ); i++ ) {
-		auto child = idx.child( i, 2 );
+		auto child = nif->index( i, 2, idx );
 		if ( nif->rowCount( child ) > 0 ) {
 			scan( child, nif, usedStrings, hasCED );
 			continue;

--- a/src/spells/sanitize.cpp
+++ b/src/spells/sanitize.cpp
@@ -52,7 +52,7 @@ public:
 				QList<QPair<qint32, bool> > links;
 
 				for ( int r = 0; r < nif->rowCount( iChildren ); r++ ) {
-					qint32 l = nif->getLink( iChildren.child( r, 0 ) );
+					qint32 l = nif->getLink( nif->index( r, 0, iChildren ) );
 
 					if ( l >= 0 ) {
 						links.append( QPair<qint32, bool>( l, nif->inherits( nif->getBlock( l ), "NiTriBasedGeom" ) ) );
@@ -62,8 +62,8 @@ public:
 				std::stable_sort( links.begin(), links.end(), compareChildLinks );
 
 				for ( int r = 0; r < links.count(); r++ ) {
-					if ( links[r].first != nif->getLink( iChildren.child( r, 0 ) ) ) {
-						nif->setLink( iChildren.child( r, 0 ), links[r].first );
+					if ( links[r].first != nif->getLink( nif->index( r, 0, iChildren ) ) ) {
+						nif->setLink( nif->index( r, 0, iChildren ), links[r].first );
 					}
 				}
 
@@ -293,7 +293,7 @@ public:
 	QModelIndex check( NifModel * nif, const QModelIndex & iParent )
 	{
 		for ( int r = 0; r < nif->rowCount( iParent ); r++ ) {
-			QModelIndex idx = iParent.child( r, 0 );
+			QModelIndex idx = nif->index( r, 0, iParent );
 			bool child;
 
 			if ( nif->isLink( idx, &child ) ) {
@@ -551,8 +551,8 @@ public:
 			auto numBlocks = nif->rowCount( controlledBlocks );
 
 			for ( int i = 0; i < numBlocks; i++ ) {
-				auto ctrlrType =  nif->getIndex( controlledBlocks.child( i, 0 ), "Controller Type" );
-				auto nodeName = nif->getIndex( controlledBlocks.child( i, 0 ), "Node Name" );
+				auto ctrlrType =  nif->getIndex( nif->index( i, 0, controlledBlocks ), "Controller Type" );
+				auto nodeName = nif->getIndex( nif->index( i, 0, controlledBlocks ), "Node Name" );
 
 				auto ctrlrTypeIdx = nif->get<int>( ctrlrType );
 				if ( ctrlrTypeIdx == -1 ) {

--- a/src/spells/stringpalette.cpp
+++ b/src/spells/stringpalette.cpp
@@ -362,7 +362,7 @@ public:
 				offsetMap.insert( oldOffsets[i], -1 );
 			} else {
 				offsetMap.insert( oldOffsets[i], x );
-				bytes += s;
+				bytes.append( (const char*)s.data() );
 				bytes.append( '\0' );
 				x += ( s.length() + 1 );
 			}
@@ -407,23 +407,23 @@ public:
 			QPersistentModelIndex blocks = nif->getIndex( nextBlock, "Controlled Blocks" );
 
 			for ( int i = 0; i < nif->rowCount( blocks ); i++ ) {
-				QPersistentModelIndex thisBlock = blocks.child( i, 0 );
+				QPersistentModelIndex thisBlock = nif->index( i, 0, blocks );
 
 				for ( int j = 0; j < nif->rowCount( thisBlock ); j++ ) {
-					if ( nif->getValue( thisBlock.child( j, 0 ) ).type() == NifValue::tStringOffset ) {
+					if ( nif->getValue( nif->index( j, 0, thisBlock ) ).type() == NifValue::tStringOffset ) {
 						// we shouldn't ever exceed the limit of an int, even though the type
 						// is properly a uint
-						int oldValue = nif->get<int>( thisBlock.child( j, 0 ) );
-						qDebug() << "Index " << thisBlock.child( j, 0 )
+						int oldValue = nif->get<int>( nif->index( j, 0, thisBlock ) );
+						qDebug() << "Index " << nif->index( j, 0, thisBlock )
 						           << " is a string offset with name "
-						           << nif->itemName( thisBlock.child( j, 0 ) )
+						           << nif->itemName( nif->index( j, 0, thisBlock ) )
 						           << " and value "
-						           << nif->get<int>( thisBlock.child( j, 0 ) );
+						           << nif->get<int>( nif->index( j, 0, thisBlock ) );
 
 
 						if ( oldValue != -1 ) {
 							int newValue = offsetMap.value( oldValue );
-							nif->set<int>( thisBlock.child( j, 0 ), newValue );
+							nif->set<int>( nif->index( j, 0, thisBlock ), newValue );
 							numRefsUpdated++;
 						}
 					}

--- a/src/spells/strippify.cpp
+++ b/src/spells/strippify.cpp
@@ -54,7 +54,7 @@ class spStrippify final : public Spell
 		int skip = 0;
 
 		for ( int t = 0; t < nif->rowCount( iTriangles ); t++ ) {
-			Triangle tri = nif->get<Triangle>( iTriangles.child( t, 0 ) );
+			Triangle tri = nif->get<Triangle>( nif->index( t, 0, iTriangles ) );
 
 			if ( tri[0] != tri[1] && tri[1] != tri[2] && tri[2] != tri[0] )
 				triangles.append( tri );
@@ -114,7 +114,7 @@ class spStrippify final : public Spell
 				nif->updateArray( iDstUV );
 
 				for ( int r = 0; r < nif->rowCount( iDstUV ); r++ ) {
-					copyArray<Vector2>( nif, iDstUV.child( r, 0 ), iSrcUV.child( r, 0 ) );
+					copyArray<Vector2>( nif, nif->index( r, 0, iDstUV ), nif->index( r, 0, iSrcUV ) );
 				}
 			}
 
@@ -125,7 +125,7 @@ class spStrippify final : public Spell
 				nif->updateArray( iDstUV );
 
 				for ( int r = 0; r < nif->rowCount( iDstUV ); r++ ) {
-					copyArray<Vector2>( nif, iDstUV.child( r, 0 ), iSrcUV.child( r, 0 ) );
+					copyArray<Vector2>( nif, nif->index( r, 0, iDstUV ), nif->index( r, 0, iSrcUV ) );
 				}
 			}
 
@@ -143,8 +143,8 @@ class spStrippify final : public Spell
 				nif->updateArray( iPoints );
 				int x = 0;
 				for ( const QVector<quint16>& strip : strips ) {
-					nif->set<int>( iLengths.child( x, 0 ), strip.count() );
-					QModelIndex iStrip = iPoints.child( x, 0 );
+					nif->set<int>( nif->index( x, 0, iLengths ), strip.count() );
+					QModelIndex iStrip = nif->index( x, 0, iPoints );
 					nif->updateArray( iStrip );
 					nif->setArray<quint16>( iStrip, strip );
 					x++;
@@ -179,10 +179,10 @@ class spStrippify final : public Spell
 			auto stripsA = strips.at(0);
 			if ( iLengths.isValid() && iPoints.isValid() ) {
 				nif->updateArray( iLengths );
-				nif->set<quint16>( iLengths.child( 0, 0 ), stripsA.count() );
+				nif->set<quint16>( nif->index( 0, 0, iLengths ), stripsA.count() );
 				nif->updateArray( iPoints );
-				nif->updateArray( iPoints.child( 0, 0 ) );
-				nif->setArray<quint16>( iPoints.child( 0, 0 ), stripsA );
+				nif->updateArray( nif->index( 0, 0, iPoints ) );
+				nif->setArray<quint16>( nif->index( 0, 0, iPoints ), stripsA );
 				nif->set<quint16>( iStripData, "Num Triangles", stripsA.count() - 2 );
 			}
 			
@@ -196,10 +196,10 @@ class spStrippify final : public Spell
 			auto stripsB = strips.at(1);
 			if ( iLengths.isValid() && iPoints.isValid() ) {
 				nif->updateArray( iLengths );
-				nif->set<quint16>( iLengths.child( 0, 0 ), stripsB.count() );
+				nif->set<quint16>( nif->index( 0, 0, iLengths ), stripsB.count() );
 				nif->updateArray( iPoints );
-				nif->updateArray( iPoints.child( 0, 0 ) );
-				nif->setArray<quint16>( iPoints.child( 0, 0 ), stripsB );
+				nif->updateArray( nif->index( 0, 0, iPoints ) );
+				nif->setArray<quint16>( nif->index( 0, 0, iPoints ), stripsB );
 				nif->set<quint16>( iStrip2Data, "Num Triangles", stripsB.count() - 2 );
 			}
 		}
@@ -273,10 +273,10 @@ class spTriangulate final : public Spell
 
 		for ( int s = 0; s < nif->rowCount( iPoints ); s++ ) {
 			QVector<quint16> strip;
-			QModelIndex iStrip = iPoints.child( s, 0 );
+			QModelIndex iStrip = nif->index( s, 0, iPoints );
 
 			for ( int p = 0; p < nif->rowCount( iStrip ); p++ )
-				strip.append( nif->get<int>( iStrip.child( p, 0 ) ) );
+				strip.append( nif->get<int>( nif->index( p, 0, iStrip ) ) );
 
 			strips.append( strip );
 		}
@@ -314,7 +314,7 @@ class spTriangulate final : public Spell
 				nif->updateArray( iDstUV );
 
 				for ( int r = 0; r < nif->rowCount( iDstUV ); r++ ) {
-					copyArray<Vector2>( nif, iDstUV.child( r, 0 ), iSrcUV.child( r, 0 ) );
+					copyArray<Vector2>( nif, nif->index( r, 0, iDstUV ), nif->index( r, 0, iSrcUV ) );
 				}
 			}
 
@@ -325,7 +325,7 @@ class spTriangulate final : public Spell
 				nif->updateArray( iDstUV );
 
 				for ( int r = 0; r < nif->rowCount( iDstUV ); r++ ) {
-					copyArray<Vector2>( nif, iDstUV.child( r, 0 ), iSrcUV.child( r, 0 ) );
+					copyArray<Vector2>( nif, nif->index( r, 0, iDstUV ), nif->index( r, 0, iSrcUV ) );
 				}
 			}
 
@@ -420,7 +420,7 @@ public:
 		QList<QVector<quint16> > strips;
 
 		for ( int r = 0; r < nif->rowCount( iPoints ); r++ )
-			strips += nif->getArray<quint16>( iPoints.child( r, 0 ) );
+			strips += nif->getArray<quint16>( nif->index( r, 0, iPoints ) );
 
 		if ( strips.isEmpty() )
 			return index;
@@ -438,10 +438,10 @@ public:
 
 		nif->set<int>( iData, "Num Strips", 1 );
 		nif->updateArray( iLength );
-		nif->set<int>( iLength.child( 0, 0 ), strip.size() );
+		nif->set<int>( nif->index( 0, 0, iLength ), strip.size() );
 		nif->updateArray( iPoints );
-		nif->updateArray( iPoints.child( 0, 0 ) );
-		nif->setArray<quint16>( iPoints.child( 0, 0 ), strip );
+		nif->updateArray( nif->index( 0, 0, iPoints ) );
+		nif->setArray<quint16>( nif->index( 0, 0, iPoints ), strip );
 
 		return index;
 	}
@@ -471,7 +471,7 @@ public:
 		if ( !( iLength.isValid() && iPoints.isValid() ) )
 			return index;
 
-		QVector<quint16> strip = nif->getArray<quint16>( iPoints.child( 0, 0 ) );
+		QVector<quint16> strip = nif->getArray<quint16>( nif->index( 0, 0, iPoints ) );
 
 		if ( strip.size() <= 3 )
 			return index;
@@ -513,9 +513,9 @@ public:
 		nif->updateArray( iPoints );
 
 		for ( int r = 0; r < strips.count(); r++ ) {
-			nif->set<int>( iLength.child( r, 0 ), strips[r].size() );
-			nif->updateArray( iPoints.child( r, 0 ) );
-			nif->setArray<quint16>( iPoints.child( r, 0 ), strips[r] );
+			nif->set<int>( nif->index( r, 0, iLength ), strips[r].size() );
+			nif->updateArray( nif->index( r, 0, iPoints ) );
+			nif->setArray<quint16>( nif->index( r, 0, iPoints ), strips[r] );
 		}
 
 		return index;

--- a/src/spells/tangentspace.cpp
+++ b/src/spells/tangentspace.cpp
@@ -96,7 +96,7 @@ QModelIndex spTangentSpace::cast( NifModel * nif, const QModelIndex & iBlock )
 		if ( !iTexCo.isValid() )
 			iTexCo = nif->getIndex( iData, "UV Sets 2" );
 
-		iTexCo = iTexCo.child( 0, 0 );
+		iTexCo = nif->index( 0, 0, iTexCo );
 		texco = nif->getArray<Vector2>( iTexCo );
 	}
 
@@ -108,7 +108,7 @@ QModelIndex spTangentSpace::cast( NifModel * nif, const QModelIndex & iBlock )
 		QVector<QVector<quint16> > strips;
 
 		for ( int r = 0; r < nif->rowCount( iPoints ); r++ )
-			strips.append( nif->getArray<quint16>( iPoints.child( r, 0 ) ) );
+			strips.append( nif->getArray<quint16>( nif->index( r, 0, iPoints ) ) );
 
 		triangles = triangulate( strips );
 	} else if ( nif->getUserVersion2() < 100 ) {
@@ -119,7 +119,7 @@ QModelIndex spTangentSpace::cast( NifModel * nif, const QModelIndex & iBlock )
 			auto numParts = nif->get<int>( iPartBlock, "Num Skin Partition Blocks" );
 			auto iParts = nif->getIndex( iPartBlock, "Partition" );
 			for ( int i = 0; i < numParts; i++ )
-				triangles << nif->getArray<Triangle>( iParts.child( i, 0 ), "Triangles" );
+				triangles << nif->getArray<Triangle>( nif->index( i, 0, iParts ), "Triangles" );
 		} else {
 			triangles = nif->getArray<Triangle>( iShape, "Triangles" );
 		}
@@ -271,7 +271,7 @@ QModelIndex spTangentSpace::cast( NifModel * nif, const QModelIndex & iBlock )
 				int numlinks = nif->get<int>( iNumExtras );
 				nif->set<int>( iNumExtras, numlinks + 1 );
 				nif->updateArray( iExtras );
-				nif->setLink( iExtras.child( numlinks, 0 ), nif->getBlockNumber( iTSpace ) );
+				nif->setLink( nif->index( numlinks, 0, iExtras ), nif->getBlockNumber( iTSpace ) );
 			}
 		}
 

--- a/src/spells/transform.cpp
+++ b/src/spells/transform.cpp
@@ -205,7 +205,7 @@ QModelIndex spApplyTransformation::cast( NifModel * nif, const QModelIndex & ind
 
 		nif->setState( BaseModel::Processing );
 		for ( int i = 0; i < nif->rowCount( iVertData ); i++ ) {
-			auto iVert = iVertData.child( i, 0 );
+			auto iVert = nif->index( i, 0, iVertData );
 
 			auto vertex = t * nif->get<Vector3>( iVert, "Vertex" );
 			if ( !nif->set<HalfVector3>( iVert, "Vertex", vertex ) )

--- a/src/ui/widgets/colorwheel.cpp
+++ b/src/ui/widgets/colorwheel.cpp
@@ -42,6 +42,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QLabel>
 #include <QLayout>
 #include <QLineEdit>
+#include <QMatrix4x4>
 #include <QPainter>
 #include <QPixmap>
 #include <QPushButton>
@@ -212,7 +213,7 @@ void ColorWheel::paintEvent( QPaintEvent * e )
 	QPainter p( this );
 	p.translate( width() / 2, height() / 2 );
 	p.setRenderHint( QPainter::Antialiasing );
-	p.setRenderHint( QPainter::HighQualityAntialiasing );
+	//FIXME: p.setRenderHint( QPainter::HighQualityAntialiasing );
 
 	p.setPen( Qt::NoPen );
 
@@ -226,7 +227,7 @@ void ColorWheel::paintEvent( QPaintEvent * e )
 
 	p.setBrush( QBrush( cgrad ) );
 	p.drawEllipse( QRectF( -s, -s, s * 2, s * 2 ) );
-	p.setBrush( palette().color( QPalette::Background ) );
+	p.setBrush( palette().color( QPalette::Base ) );
 	p.drawEllipse( QRectF( -c, -c, c * 2, c * 2 ) );
 
 	double x = ( H - 0.5 ) * 2 * M_PI;
@@ -342,7 +343,7 @@ void ColorWheel::setColor( int x, int y )
 {
 	if ( pressed == Circle ) {
 		QLineF l( QPointF( width() / 2.0, height() / 2.0 ), QPointF( x, y ) );
-		H = l.angle( QLineF( 0, 1, 0, 0 ) ) / 360.0;
+		H = l.angleTo( QLineF( 0, 1, 0, 0 ) ) / 360.0;
 
 		if ( l.dx() > 0 )
 			H = 1.0 - H;
@@ -353,8 +354,8 @@ void ColorWheel::setColor( int x, int y )
 	} else if ( pressed == Triangle ) {
 		QPointF mp( x - width() / 2, y - height() / 2 );
 
-		QMatrix m;
-		m.rotate( (H ) * 360.0 + 120 );
+		QMatrix4x4 m;
+		m.rotate( (H ) * 360.0 + 120, 0.0, 0.0, 1.0 );
 		QPointF p( m.map( mp ) );
 		double c = qMin( width(), height() ) / 2.0;
 		c -= c / 5;

--- a/src/ui/widgets/fileselect.cpp
+++ b/src/ui/widgets/fileselect.cpp
@@ -75,7 +75,7 @@ FileSelector::FileSelector( Modes mode, const QString & buttonText, QBoxLayout::
 	: QWidget(), Mode( mode ), dirmdl( 0 ), completer( 0 )
 {
 	QBoxLayout * lay = new QBoxLayout( dir, this );
-	lay->setMargin( 0 );
+	lay->setContentsMargins( 0, 0, 0, 0 );
 	setLayout( lay );
 
 	line = new QLineEdit( this );

--- a/src/ui/widgets/floatslider.cpp
+++ b/src/ui/widgets/floatslider.cpp
@@ -59,7 +59,7 @@ FloatSliderEditBox::FloatSliderEditBox( QWidget * parent )
 	setMaximumWidth( 100 );
 
 	QVBoxLayout * layout = new QVBoxLayout();
-	layout->setMargin( 4 );
+	layout->setContentsMargins( 4, 4, 4, 4 );
 	layout->setSpacing( 2 );
 	setLayout( layout );
 }
@@ -234,7 +234,7 @@ QStyleOptionSlider FloatSlider::getStyleOption() const
 	opt.activeSubControls = QStyle::SC_None;
 
 	if ( showVal ) {
-		int w = fontMetrics().width( "0.000" );
+		int w = fontMetrics().horizontalAdvance( "0.000" );
 //#pragma message("NOTICE: Qt Bugfix is needed here, see http://pastebin.mozilla.org/101393")
 		opt.rect.adjust( (6 * w) / 10, VAL_HEIGHT, (-6 * w) / 10, 0 );
 	}

--- a/src/ui/widgets/groupbox.h
+++ b/src/ui/widgets/groupbox.h
@@ -47,9 +47,9 @@ public:
 	GroupBox( const QString & title, Qt::Orientation o );
 	~GroupBox();
 
-	void addWidget( QWidget * widget, int stretch = 0, Qt::Alignment alignment = 0 );
+	void addWidget( QWidget * widget, int stretch = 0, Qt::Alignment alignment = Qt::Alignment() );
 
-	QWidget * pushLayout( const QString & name, Qt::Orientation o, int stretch = 0, Qt::Alignment alignment = 0 );
+	QWidget * pushLayout( const QString & name, Qt::Orientation o, int stretch = 0, Qt::Alignment alignment = Qt::Alignment() );
 	void pushLayout( Qt::Orientation o, int stretch = 0 );
 
 	void popLayout();

--- a/src/ui/widgets/inspect.h
+++ b/src/ui/widgets/inspect.h
@@ -50,7 +50,7 @@ class InspectView final : public QDialog
 	Q_OBJECT
 
 public:
-	explicit InspectView( QWidget * parent = 0, Qt::WindowFlags f = 0 );
+	explicit InspectView( QWidget * parent = 0, Qt::WindowFlags f = Qt::WindowFlags() );
 	~InspectView();
 
 	QSize minimumSizeHint() const override final { return { 50, 50 }; }

--- a/src/ui/widgets/nifcheckboxlist.cpp
+++ b/src/ui/widgets/nifcheckboxlist.cpp
@@ -249,7 +249,7 @@ void NifCheckBoxList::parseText( const QString & text )
 	if ( !text.isEmpty() ) {
 		// Build RegEx for efficient search. Then set model to match
 		QString str;
-		QStringList list = text.split( QRegularExpression( "\\s*\\|\\s*" ), QString::SkipEmptyParts );
+		QStringList list = text.split( QRegularExpression( "\\s*\\|\\s*" ), Qt::SkipEmptyParts );
 		QStringListIterator lit( list );
 
 		while ( lit.hasNext() ) {

--- a/src/ui/widgets/nifview.h
+++ b/src/ui/widgets/nifview.h
@@ -46,7 +46,7 @@ class NifTreeView final : public QTreeView
 
 public:
 	//! Constructor
-	NifTreeView( QWidget * parent = 0, Qt::WindowFlags flags = 0 );
+	NifTreeView( QWidget * parent = 0, Qt::WindowFlags flags = Qt::Widget );
 	//! Destructor
 	~NifTreeView();
 
@@ -93,7 +93,7 @@ protected:
 	void drawBranches( QPainter * painter, const QRect & rect, const QModelIndex & index ) const override final;
 	void keyPressEvent( QKeyEvent * e ) override final;
 
-	QStyleOptionViewItem viewOptions() const override final;
+	QStyleOptionViewItem viewOptions() const /*override*/ /*final*/;
 
 	void autoExpand( const QModelIndex & index );
 

--- a/src/ui/widgets/uvedit.h
+++ b/src/ui/widgets/uvedit.h
@@ -35,7 +35,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "data/niftypes.h"
 
-#include <QGLWidget> // Inherited
+#include <QOpenGLWidget> // Inherited
 #include <QDialog>   // Inherited
 #include <QModelIndex>
 #include <QPointer>
@@ -56,7 +56,7 @@ class QUndoStack;
 #undef None // conflicts with Qt
 
 //! Displays and allows editing of UV coordinate data
-class UVWidget final : public QGLWidget
+class UVWidget final : public QOpenGLWidget
 {
 	Q_OBJECT
 


### PR DESCRIPTION
Mostly applying:

`([a-zA-Z0-0]*).child\( ([a-zA-Z0-9\\ \-]+), ([a-zA-Z0-9\\:]+) \)` to `nif->index( $2, $3, $1 )`

Many lines will contain `FIXME:`; this is where I definitely broke some behaviour.

Does not compile yet. I don't plan to work on this any further.

